### PR TITLE
Add HR/EU interactive map zoom toggle; other minor fixes and optimizations

### DIFF
--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -66,35 +66,35 @@
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
 		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
-		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+		;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
+		n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
 		const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar");let o=0;const n=()=>{const n=o/e.length*100
 		;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.querySelector(".progress-container").style.display="none"},500)};e.forEach(e=>{
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
-		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}
-		function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1
-		;const i=parseInt(e.getAttribute("data-slideshow-id"));e.querySelectorAll("img").forEach(e=>{
+		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
+		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
-		s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
-		e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(i,t,n)}}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(i,t,n),s=!1}}),
-		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}window.addEventListener("load",function(){
-		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})})
-		;let previousWidth=0,zoomMap=new Map;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
-		setIframeSrc("windy"),setIframeSrc("blitzortung"),setIframeSrc("weatherAndRadar"),setIframeSrc("rainViewer"),setIframeSrc("ventussky"))}
-		function setIframeSrc(e){dlog(`Updating iframe src for ${e}`);const t=document.getElementById(e);if(t){
-		let o=zoomMap.get(e),n=t.getAttribute("data-src");if(o&&o.length>0){let e=o[0],t=o[1];window.innerWidth<800&&(n=n.replace(e,t))}t.src=n
-		}else dlog(`${e} not found, skipping updateIframeSrc for ${e}`)}function hideOverlayOnDoubleTap(){
-		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
-		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
-		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
+		i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
+		e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
+		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
+		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
+		;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
+		document.querySelectorAll("iframe[data-zoom-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
+		dlog(`Updating iframe src for ${e.id}`);let t=e.getAttribute("data-src")
+		;window.innerWidth<800&&(t=t.replace(e.getAttribute("data-zoom-desktop"),e.getAttribute("data-zoom-mobile"))),e.src=t}
+		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{
+		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+		e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
+		;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,s=Math.abs(t-r),a=Math.abs(i-n);s<10&&a<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -105,29 +105,25 @@
 		restoreOverlay(getFrameIdFromResetButtonId(t.id))}),t.textContent="[X]"}function setResetButtonToReset(e){
 		dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 		e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
-		dlog(`Resetting iframe: ${e}`),setIframeSrc(e);const t=getResetButtonFromFrameId(e);t.style.display="none",setResetButtonToExit(t)}
-		function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
-		return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
-		return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
-		;if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit();e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
-		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
-		;dlog("dtg: "+r),dlog("end: "+s)
-		;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+		dlog(`Resetting iframe: ${e}`),setIframeSrc(document.getElementById(e));const t=getResetButtonFromFrameId(e);t.style.display="none",
+		setResetButtonToExit(t)}function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}
+		function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}
+		function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){
+		const t=document.getElementById("essl");if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit()
+		;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
+		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
+		;dlog("dtg: "+r),dlog("end: "+i)
+		;let s=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function a(){
 		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=s}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
-		function DTGFromDateInHours(e){
-		return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2),result}
-		function EndValue(e){return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06",result}
-		function pad(e,t,o){return o=o||"0",(e+="").length>=t?e:new Array(t-e.length+1).join(o)+e}zoomMap.set("windy",["&zoom=7","&zoom=6"]),
-		zoomMap.set("blitzortung",["#6/","#5/"]),zoomMap.set("weatherAndRadar",["&zoom=7.2","&zoom=6.8"]),
-		zoomMap.set("rainViewer",[",6.3&",",5.8&"]),zoomMap.set("ventussky",[";6&",";6&"]);let isDebugEnabled=!1;function getUrlParameter(e){
-		return new URLSearchParams(window.location.search).get(e)}function dlog(...e){isDebugEnabled&&console.log(...e)}
-		"1"===getUrlParameter("debug")&&(isDebugEnabled=!0),document.addEventListener("DOMContentLoaded",()=>{showProgress(),
-		addExpandableClickEventListener(),addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),
-		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
-		updateHintText()},200)});
+		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
+		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
+		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
+		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{showProgress(),addExpandableClickEventListener(),
+		addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
+		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>
@@ -162,7 +158,7 @@
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -178,7 +174,7 @@
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&" frameborder="0"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -194,7 +190,7 @@
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -67,8 +67,8 @@
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
 		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
-		n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
+		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -77,28 +77,28 @@
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
-		i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
-		e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
-		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
-		;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
+		s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
+		e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
+		e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
+		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}let previousWidth=0;function updateIframeSrc(){
+		window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
 		;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
 		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
 		;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
 		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
-		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]"}function hideOverlayOnDoubleTap(){
-		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
-		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
-		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,a=Math.abs(t-r),s=Math.abs(i-n);a<10&&s<10&&(o.style.opacity="0.6",
+		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getResetButtonFromFrameId(e)
+		;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
+		let t=0;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
+		setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
+		;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -115,18 +115,19 @@
 		function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){
 		const t=document.getElementById("essl");if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit()
 		;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
-		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
-		;dlog("dtg: "+r),dlog("end: "+i)
-		;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function s(){
-		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",s),setEsslImgSrc(e+1);else{
+		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
+		;dlog("dtg: "+r),dlog("end: "+s)
+		;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",s),t.addEventListener("error",s),t.src=a}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
-		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{showProgress(),addExpandableClickEventListener(),
-		addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
+		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
+		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
 		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -28,32 +28,33 @@
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}table{width
 		:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}.radartitle{position:relative;max-width:100%}.radartitle .center{
 		transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
-		none}.radartitle .right:hover{cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;
-		overflow:hidden;padding-top:100%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:
-		100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
-		background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
-		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
-		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
-		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-		10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size
-		:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline
-		:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em}.fade{animation-name:
-		fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#c7c7c7}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
+		display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:100%}@media (max-width:800px){.if1{padding-top:110%}}
+		.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;
+		position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;
+		min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;
+		width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
+		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
+		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
+		calc(100% / .6);transform-origin:0 0}}.sp{height:10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}
+		.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;
+		cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;
+		display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
+		align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
+		user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}
+		.prev.shorter{top:.4em}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
+		color:#fff}.next.shorter{top:.4em}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:
+		background-color .3s}.indicator.active{background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:
+		relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
+		width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
+		2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
+		max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
+		0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
+		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
+		width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -79,22 +80,25 @@
 		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
 		i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
-		e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),
+		e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+		e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
 		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
 		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
 		;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
-		document.querySelectorAll("iframe[data-zoom-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
-		dlog(`Updating iframe src for ${e.id}`);let t=e.getAttribute("data-src")
-		;window.innerWidth<800&&(t=t.replace(e.getAttribute("data-zoom-desktop"),e.getAttribute("data-zoom-mobile"))),e.src=t}
-		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{
-		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-		e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
-		;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-		n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,s=Math.abs(t-r),a=Math.abs(i-n);s<10&&a<10&&(o.style.opacity="0.6",
+		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
+		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
+		;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
+		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
+		;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
+		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
+		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]"}function hideOverlayOnDoubleTap(){
+		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
+		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
+		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
+		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,a=Math.abs(t-r),s=Math.abs(i-n);a<10&&s<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -113,10 +117,10 @@
 		;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
 		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
 		;dlog("dtg: "+r),dlog("end: "+i)
-		;let s=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function a(){
-		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
+		;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function s(){
+		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",s),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=s}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",s),t.addEventListener("error",s),t.src=a}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
@@ -154,11 +158,15 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventussky', this)">[HR]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" frameborder="0"
+								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-hr-desktop=";6&" data-zoom-hr-mobile=";6&"
+								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off" data-zoom-eu-desktop=";4&" data-zoom-eu-mobile=";3&">
+						</iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -170,11 +178,15 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('rainViewer', this)">[HR]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" frameborder="0"
+								data-src-hr="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-hr-desktop=",6.3&" data-zoom-hr-mobile=",5.8&"
+								data-src-eu="https://www.rainviewer.com/map.html?loc=48.0,10.0,4.0&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-eu-desktop=",4.0&" data-zoom-eu-mobile=",3.2&">
+						</iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -186,11 +198,15 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-hr-desktop="&zoom=7.2" data-zoom-hr-mobile="&zoom=6.8" data-zoom-eu-desktop="&zoom=5.0" data-zoom-eu-mobile="&zoom=4.0"
+								data-src-hr="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true"
+								data-src-eu="https://radar.wo-cloud.com/pwa/?center=48.0,10.0&zoom=5.0&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true">
+						</iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -57,30 +57,31 @@
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
-		;t&&t.scrollIntoView({behavior:"smooth",block:"start"})}async function addExpandableClickEventListener(){
-		document.getElementsByClassName("expandable")[0].addEventListener("click",function(){let e=this.querySelector(".arrow")
-		;var t=document.getElementsByClassName("links")[0];t.style.maxHeight?(t.style.maxHeight=null,
+		;t&&t.scrollIntoView({behavior:"smooth",block:"start"})}function addExpandableClickEventListener(){
+		document.querySelector(".expandable").addEventListener("click",function(){let e=this.querySelector(".arrow")
+		;const t=document.querySelector(".links");t.style.maxHeight?(t.style.maxHeight=null,
 		e.textContent="▼"):(t.style.maxHeight=t.scrollHeight+"px",e.textContent="▲",setTimeout(()=>{
 		document.documentElement.style.scrollBehavior="auto",document.body.style.scrollBehavior="auto",scrollToElement("links"),setTimeout(()=>{
-		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}
-		let slidePage=[2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1];function plusSlides(e,t){showSlides(e,slidePage[e-1]+=t)}function showSlides(e,t){
-		const o=document.querySelectorAll(`.slideshow[data-slideshow-id="${e}"] .slide`),n=document.querySelectorAll(`.indicators-container[data-slideshow-id="${e}"] .indicator`)
-		;t>o.length&&(slidePage[e-1]=1),t<1&&(slidePage[e-1]=o.length),o.forEach(e=>e.classList.remove("active")),
-		o[slidePage[e-1]-1].classList.add("active"),n.forEach(e=>e.classList.remove("active")),n[slidePage[e-1]-1].classList.add("active"),
-		updateSlideshowWidth(e)}function updateSlideshowWidth(e){if(16!==e&&17!==e)return
-		;const t=document.querySelector(`.slideshow[data-slideshow-id='${e}']`),o=document.querySelector(`.indicators-container[data-slideshow-id='${e}']`),n=t.querySelector(".slide.active .placeholder")
-		;t.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
-		const e=document.querySelectorAll("img"),t=document.getElementsByClassName("progress-bar")[0];let o=0;const n=()=>{const n=o/e.length*100
-		;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.getElementsByClassName("progress-container")[0].style.display="none"},500)}
-		;e.forEach(e=>{e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),
-		e.removeAttribute("src"),n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t
-		;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{
-		let t=0,o=0,n=0,r=0,s=!1;const a=e.getAttribute("data-slideshow-id");e.querySelectorAll("img").forEach(e=>{
+		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}function plusSlides(e,t){
+		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
+		function showSlides(e,t){
+		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
+		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
+		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
+		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
+		const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar");let o=0;const n=()=>{const n=o/e.length*100
+		;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.querySelector(".progress-container").style.display="none"},500)};e.forEach(e=>{
+		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
+		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}
+		function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1
+		;const i=parseInt(e.getAttribute("data-slideshow-id"));e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
 		s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
-		e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(a,t,n)}}),
+		e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(i,t,n)}}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const i=n-t,l=r-o;Math.abs(i)>Math.abs(l)&&handleSwipe(a,t,n),s=!1}}),
+		e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(i,t,n),s=!1}}),
 		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}window.addEventListener("load",function(){
 		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})})
 		;let previousWidth=0,zoomMap=new Map;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
@@ -93,7 +94,7 @@
 		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
 		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
 		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,a=Math.abs(t-r),i=Math.abs(s-n);a<10&&i<10&&(o.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -105,17 +106,16 @@
 		dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 		e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
 		dlog(`Resetting iframe: ${e}`),setIframeSrc(e);const t=getResetButtonFromFrameId(e);t.style.display="none",setResetButtonToExit(t)}
-		function getResetButtonFromFrameId(e){return document.getElementById("reset"+String(e).charAt(0).toUpperCase()+String(e).slice(1)+"Frame")}
-		function getResetButtonFromOverlayId(e){return document.getElementById(e.replace("overlay","reset"))}
-		function getFrameIdFromResetButtonId(e){let t=e.replace("reset","").replace("Frame","")
-		;return String(t).charAt(0).toLowerCase()+String(t).slice(1)}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
+		function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
+		return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
+		return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
 		;if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit();e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
 		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
 		;dlog("dtg: "+r),dlog("end: "+s)
-		;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function i(){
-		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",i),setEsslImgSrc(e+1);else{
+		;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",i),t.addEventListener("error",i),t.src=a}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){
 		return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2),result}
@@ -159,11 +159,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a class="right" id="resetVentusskyFrame" style="display:none">[X]</a>
+						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
-						<div class="overlay" id="overlayVentusskyFrame">
+						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -175,11 +175,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a class="right" id="resetRainViewerFrame" style="display:none">[X]</a>
+						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
-						<div class="overlay" id="overlayRainViewerFrame">
+						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -191,11 +191,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
-						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
+						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
-						<div class="overlay" id="overlayWeatherAndRadarFrame">
+						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -206,7 +206,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.arso.gov.si/met/sl/weather/observ/radar/" target="_blank" rel="nofollow">meteo.si</a>
-					<div class="slideshow placeholder" data-slideshow-id="6" style="max-width: 821px; aspect-ratio: 821 / 660; ">
+					<div class="slideshow placeholder" data-slideshow-id="6" data-current-slide="1" style="max-width: 821px; aspect-ratio: 821 / 660; ">
 						<div class="slide fade active">
 							<img src="https://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm-anim.gif?nocache" />
 						</div>
@@ -287,7 +287,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=puntijarka&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Puntijarka</a>
-					<div class="slideshow placeholder" data-slideshow-id="8" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="8" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_puntijarka.gif" />
 						</div>
@@ -308,7 +308,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=bilogora&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Bilogora</a>
-					<div class="slideshow placeholder" data-slideshow-id="9" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="9" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_bilogora.gif" />
 						</div>
@@ -329,7 +329,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=gradiste&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Gradište</a>
-					<div class="slideshow placeholder" data-slideshow-id="10" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="10" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_gradiste.gif" />
 						</div>
@@ -350,7 +350,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=goli&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Goli</a>
-					<div class="slideshow placeholder" data-slideshow-id="11" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="11" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_goli.gif" />
 						</div>
@@ -371,7 +371,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=debeljak&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Debeljak</a>
-					<div class="slideshow placeholder" data-slideshow-id="12" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="12" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_debeljak.gif" />
 						</div>
@@ -392,7 +392,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=uljenje&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Uljenje</a>
-					<div class="slideshow placeholder" data-slideshow-id="13" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="13" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_uljenje.gif" />
 						</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,30 +57,31 @@
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
-		;t&&t.scrollIntoView({behavior:"smooth",block:"start"})}async function addExpandableClickEventListener(){
-		document.getElementsByClassName("expandable")[0].addEventListener("click",function(){let e=this.querySelector(".arrow")
-		;var t=document.getElementsByClassName("links")[0];t.style.maxHeight?(t.style.maxHeight=null,
+		;t&&t.scrollIntoView({behavior:"smooth",block:"start"})}function addExpandableClickEventListener(){
+		document.querySelector(".expandable").addEventListener("click",function(){let e=this.querySelector(".arrow")
+		;const t=document.querySelector(".links");t.style.maxHeight?(t.style.maxHeight=null,
 		e.textContent="▼"):(t.style.maxHeight=t.scrollHeight+"px",e.textContent="▲",setTimeout(()=>{
 		document.documentElement.style.scrollBehavior="auto",document.body.style.scrollBehavior="auto",scrollToElement("links"),setTimeout(()=>{
-		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}
-		let slidePage=[2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1];function plusSlides(e,t){showSlides(e,slidePage[e-1]+=t)}function showSlides(e,t){
-		const o=document.querySelectorAll(`.slideshow[data-slideshow-id="${e}"] .slide`),n=document.querySelectorAll(`.indicators-container[data-slideshow-id="${e}"] .indicator`)
-		;t>o.length&&(slidePage[e-1]=1),t<1&&(slidePage[e-1]=o.length),o.forEach(e=>e.classList.remove("active")),
-		o[slidePage[e-1]-1].classList.add("active"),n.forEach(e=>e.classList.remove("active")),n[slidePage[e-1]-1].classList.add("active"),
-		updateSlideshowWidth(e)}function updateSlideshowWidth(e){if(16!==e&&17!==e)return
-		;const t=document.querySelector(`.slideshow[data-slideshow-id='${e}']`),o=document.querySelector(`.indicators-container[data-slideshow-id='${e}']`),n=t.querySelector(".slide.active .placeholder")
-		;t.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
-		const e=document.querySelectorAll("img"),t=document.getElementsByClassName("progress-bar")[0];let o=0;const n=()=>{const n=o/e.length*100
-		;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.getElementsByClassName("progress-container")[0].style.display="none"},500)}
-		;e.forEach(e=>{e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),
-		e.removeAttribute("src"),n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t
-		;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{
-		let t=0,o=0,n=0,r=0,s=!1;const a=e.getAttribute("data-slideshow-id");e.querySelectorAll("img").forEach(e=>{
+		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}function plusSlides(e,t){
+		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
+		function showSlides(e,t){
+		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
+		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
+		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
+		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
+		const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar");let o=0;const n=()=>{const n=o/e.length*100
+		;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.querySelector(".progress-container").style.display="none"},500)};e.forEach(e=>{
+		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
+		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}
+		function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1
+		;const i=parseInt(e.getAttribute("data-slideshow-id"));e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
 		s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
-		e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(a,t,n)}}),
+		e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(i,t,n)}}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const i=n-t,l=r-o;Math.abs(i)>Math.abs(l)&&handleSwipe(a,t,n),s=!1}}),
+		e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(i,t,n),s=!1}}),
 		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}window.addEventListener("load",function(){
 		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})})
 		;let previousWidth=0,zoomMap=new Map;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
@@ -93,7 +94,7 @@
 		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
 		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
 		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,a=Math.abs(t-r),i=Math.abs(s-n);a<10&&i<10&&(o.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -105,17 +106,16 @@
 		dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 		e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
 		dlog(`Resetting iframe: ${e}`),setIframeSrc(e);const t=getResetButtonFromFrameId(e);t.style.display="none",setResetButtonToExit(t)}
-		function getResetButtonFromFrameId(e){return document.getElementById("reset"+String(e).charAt(0).toUpperCase()+String(e).slice(1)+"Frame")}
-		function getResetButtonFromOverlayId(e){return document.getElementById(e.replace("overlay","reset"))}
-		function getFrameIdFromResetButtonId(e){let t=e.replace("reset","").replace("Frame","")
-		;return String(t).charAt(0).toLowerCase()+String(t).slice(1)}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
+		function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
+		return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
+		return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
 		;if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit();e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
 		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
 		;dlog("dtg: "+r),dlog("end: "+s)
-		;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function i(){
-		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",i),setEsslImgSrc(e+1);else{
+		;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",i),t.addEventListener("error",i),t.src=a}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){
 		return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2),result}
@@ -158,7 +158,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Hrvatska</a>
-					<div class="slideshow placeholder" data-slideshow-id="1" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="1" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/radar/latest_hr.webp" class="lazy" />
 						</div>
@@ -183,7 +183,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Hrvatska</a>
-					<div class="slideshow placeholder" data-slideshow-id="2" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="2" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/sat/latest_vis_hr.webp" class="lazy" />
 						</div>
@@ -208,7 +208,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Europa</a>
-					<div class="slideshow placeholder" data-slideshow-id="3" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="3" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/radar/latest_eu2.webp" class="lazy" />
 						</div>
@@ -233,7 +233,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Europa</a>
-					<div class="slideshow placeholder" data-slideshow-id="4" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="4" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/sat/latest_vis_eu2.webp" class="lazy" />
 						</div>
@@ -259,11 +259,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a class="right" id="resetWindyFrame" style="display:none">[X]</a>
+						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" frameborder="0"></iframe>
-						<div class="overlay" id="overlayWindyFrame">
+						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -274,7 +274,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | kompozit</a>
-					<div class="slideshow placeholder" data-slideshow-id="7" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="7" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_kompozit.gif" />
 						</div>
@@ -294,7 +294,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="15" style="max-width: 768px;">
+					<div class="slideshow" data-slideshow-id="15" data-current-slide="1" style="max-width: 768px;">
 						<div class="slide fade active">
 							<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel.fr | Temperatura </a>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
@@ -322,11 +322,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
-						<a class="right" id="resetBlitzortungFrame" style="display:none">[X]</a>
+						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" frameborder="0"></iframe>
-						<div class="overlay" id="overlayBlitzortungFrame">
+						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -336,7 +336,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="16">
+					<div class="slideshow" data-slideshow-id="16" data-current-slide="1" data-dynamic-width>
 						<div class="slide fade active">
 							<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
 							<div class="placeholder" style="max-width: 900px; aspect-ratio: 900 / 600; ">
@@ -379,7 +379,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="5" style="max-width: 768px;">
+					<div class="slideshow" data-slideshow-id="5" data-current-slide="1" style="max-width: 768px;">
 						<div class="slide fade active">
 							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
@@ -407,7 +407,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="17" style="max-width: 760px;">
+					<div class="slideshow" data-slideshow-id="17" data-current-slide="1" data-dynamic-width style="max-width: 760px;">
 						<div class="slide fade active">
 							<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 493; overflow: hidden;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,8 +67,8 @@
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
 		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
-		n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
+		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -77,28 +77,28 @@
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
-		i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
-		e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
-		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
-		;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
+		s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
+		e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
+		e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
+		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}let previousWidth=0;function updateIframeSrc(){
+		window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
 		;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
 		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
 		;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
 		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
-		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]"}function hideOverlayOnDoubleTap(){
-		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
-		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
-		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,a=Math.abs(t-r),s=Math.abs(i-n);a<10&&s<10&&(o.style.opacity="0.6",
+		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getResetButtonFromFrameId(e)
+		;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
+		let t=0;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
+		setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
+		;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -115,18 +115,19 @@
 		function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){
 		const t=document.getElementById("essl");if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit()
 		;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
-		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
-		;dlog("dtg: "+r),dlog("end: "+i)
-		;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function s(){
-		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",s),setEsslImgSrc(e+1);else{
+		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
+		;dlog("dtg: "+r),dlog("end: "+s)
+		;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",s),t.addEventListener("error",s),t.src=a}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
-		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{showProgress(),addExpandableClickEventListener(),
-		addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
+		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
+		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
 		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,35 +66,35 @@
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
 		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
-		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+		;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
+		n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
 		const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar");let o=0;const n=()=>{const n=o/e.length*100
 		;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.querySelector(".progress-container").style.display="none"},500)};e.forEach(e=>{
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
-		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}
-		function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1
-		;const i=parseInt(e.getAttribute("data-slideshow-id"));e.querySelectorAll("img").forEach(e=>{
+		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
+		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
-		s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
-		e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(i,t,n)}}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(i,t,n),s=!1}}),
-		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}window.addEventListener("load",function(){
-		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})})
-		;let previousWidth=0,zoomMap=new Map;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
-		setIframeSrc("windy"),setIframeSrc("blitzortung"),setIframeSrc("weatherAndRadar"),setIframeSrc("rainViewer"),setIframeSrc("ventussky"))}
-		function setIframeSrc(e){dlog(`Updating iframe src for ${e}`);const t=document.getElementById(e);if(t){
-		let o=zoomMap.get(e),n=t.getAttribute("data-src");if(o&&o.length>0){let e=o[0],t=o[1];window.innerWidth<800&&(n=n.replace(e,t))}t.src=n
-		}else dlog(`${e} not found, skipping updateIframeSrc for ${e}`)}function hideOverlayOnDoubleTap(){
-		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
-		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
-		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
+		i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
+		e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
+		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
+		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
+		;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
+		document.querySelectorAll("iframe[data-zoom-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
+		dlog(`Updating iframe src for ${e.id}`);let t=e.getAttribute("data-src")
+		;window.innerWidth<800&&(t=t.replace(e.getAttribute("data-zoom-desktop"),e.getAttribute("data-zoom-mobile"))),e.src=t}
+		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{
+		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+		e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
+		;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,s=Math.abs(t-r),a=Math.abs(i-n);s<10&&a<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -105,29 +105,25 @@
 		restoreOverlay(getFrameIdFromResetButtonId(t.id))}),t.textContent="[X]"}function setResetButtonToReset(e){
 		dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 		e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
-		dlog(`Resetting iframe: ${e}`),setIframeSrc(e);const t=getResetButtonFromFrameId(e);t.style.display="none",setResetButtonToExit(t)}
-		function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
-		return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
-		return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
-		;if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit();e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
-		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
-		;dlog("dtg: "+r),dlog("end: "+s)
-		;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+		dlog(`Resetting iframe: ${e}`),setIframeSrc(document.getElementById(e));const t=getResetButtonFromFrameId(e);t.style.display="none",
+		setResetButtonToExit(t)}function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}
+		function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}
+		function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){
+		const t=document.getElementById("essl");if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit()
+		;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
+		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
+		;dlog("dtg: "+r),dlog("end: "+i)
+		;let s=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function a(){
 		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=s}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
-		function DTGFromDateInHours(e){
-		return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2),result}
-		function EndValue(e){return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06",result}
-		function pad(e,t,o){return o=o||"0",(e+="").length>=t?e:new Array(t-e.length+1).join(o)+e}zoomMap.set("windy",["&zoom=7","&zoom=6"]),
-		zoomMap.set("blitzortung",["#6/","#5/"]),zoomMap.set("weatherAndRadar",["&zoom=7.2","&zoom=6.8"]),
-		zoomMap.set("rainViewer",[",6.3&",",5.8&"]),zoomMap.set("ventussky",[";6&",";6&"]);let isDebugEnabled=!1;function getUrlParameter(e){
-		return new URLSearchParams(window.location.search).get(e)}function dlog(...e){isDebugEnabled&&console.log(...e)}
-		"1"===getUrlParameter("debug")&&(isDebugEnabled=!0),document.addEventListener("DOMContentLoaded",()=>{showProgress(),
-		addExpandableClickEventListener(),addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),
-		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
-		updateHintText()},200)});
+		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
+		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
+		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
+		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{showProgress(),addExpandableClickEventListener(),
+		addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
+		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>
@@ -262,7 +258,7 @@
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" frameborder="0"></iframe>
+						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -325,7 +321,7 @@
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" frameborder="0"></iframe>
+						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/" frameborder="0"></iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,32 +28,33 @@
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}table{width
 		:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}.radartitle{position:relative;max-width:100%}.radartitle .center{
 		transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
-		none}.radartitle .right:hover{cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;
-		overflow:hidden;padding-top:100%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:
-		100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
-		background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
-		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
-		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
-		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-		10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size
-		:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline
-		:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em}.fade{animation-name:
-		fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#c7c7c7}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
+		display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:100%}@media (max-width:800px){.if1{padding-top:110%}}
+		.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;
+		position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;
+		min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;
+		width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
+		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
+		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
+		calc(100% / .6);transform-origin:0 0}}.sp{height:10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}
+		.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;
+		cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;
+		display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
+		align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
+		user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}
+		.prev.shorter{top:.4em}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
+		color:#fff}.next.shorter{top:.4em}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:
+		background-color .3s}.indicator.active{background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:
+		relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
+		width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
+		2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
+		max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
+		0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
+		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
+		width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -79,22 +80,25 @@
 		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
 		i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
-		e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),
+		e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+		e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
 		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
 		document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
 		;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
-		document.querySelectorAll("iframe[data-zoom-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
-		dlog(`Updating iframe src for ${e.id}`);let t=e.getAttribute("data-src")
-		;window.innerWidth<800&&(t=t.replace(e.getAttribute("data-zoom-desktop"),e.getAttribute("data-zoom-mobile"))),e.src=t}
-		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{
-		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-		e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
-		;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-		n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,s=Math.abs(t-r),a=Math.abs(i-n);s<10&&a<10&&(o.style.opacity="0.6",
+		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
+		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
+		;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
+		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
+		;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
+		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
+		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]"}function hideOverlayOnDoubleTap(){
+		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
+		const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
+		setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
+		1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+		;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,a=Math.abs(t-r),s=Math.abs(i-n);a<10&&s<10&&(o.style.opacity="0.6",
 		clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -113,10 +117,10 @@
 		;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
 		;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
 		;dlog("dtg: "+r),dlog("end: "+i)
-		;let s=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function a(){
-		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
+		;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function s(){
+		if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",s),setEsslImgSrc(e+1);else{
 		dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-		t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=s}function GetLastInit(){let e=new Date
+		t.parentNode.appendChild(e)}}t.removeEventListener("error",s),t.addEventListener("error",s),t.src=a}function GetLastInit(){let e=new Date
 		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
@@ -254,11 +258,15 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('windy', this)">[HR]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6" frameborder="0"></iframe>
+						<iframe id="windy" loading="lazy" frameborder="0"
+								data-src-hr="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-hr-desktop="&zoom=7" data-zoom-hr-mobile="&zoom=6"
+								data-src-eu="https://embed.windy.com/embed2.html?lat=48.0&lon=10.00&zoom=5&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-eu-desktop="&zoom=5" data-zoom-eu-mobile="&zoom=3">
+						</iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -317,11 +325,15 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/" frameborder="0"></iframe>
+						<iframe id="blitzortung" loading="lazy" frameborder="0"
+								data-src-hr="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-hr-desktop="#6/" data-zoom-hr-mobile="#5/"
+								data-src-eu="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#4/48.0/10.0" data-zoom-eu-desktop="#4/" data-zoom-eu-mobile="#2.5/">
+						</iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -50,6 +50,11 @@ table {
 			cursor: pointer;
 		}
 
+	.radartitle .zoom-btn {
+		text-decoration: none;
+		cursor: pointer;
+	}
+
 img {
 	max-width: 100%;
 	height: auto;

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -1,29 +1,30 @@
 body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}table{width
 :100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}.radartitle{position:relative;max-width:100%}.radartitle .center{
 transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
-none}.radartitle .right:hover{cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;
-overflow:hidden;padding-top:100%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:
-100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
-background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
-position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
-position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
-100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size
-:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline
-:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{right:0;text-align:right}
-.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em}.fade{animation-name:
-fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#c7c7c7}
-@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
-2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
+display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:100%}@media (max-width:800px){.if1{padding-top:110%}}
+.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;
+position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;
+min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;
+width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
+;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
+calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
+calc(100% / .6);transform-origin:0 0}}.sp{height:10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}
+.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;
+cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;
+display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
+align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
+user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}
+.prev.shorter{top:.4em}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
+color:#fff}.next.shorter{top:.4em}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:
+background-color .3s}.indicator.active{background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:
+relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
+width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
+2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
+max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
+0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
+0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
+width .3s ease-in-out}

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -15,7 +15,7 @@ function scrollToElement(id) {
 	}
 }
 
-async function addExpandableClickEventListener() {
+function addExpandableClickEventListener() {
 	var expandable = document.getElementsByClassName("expandable")[0];
 	expandable.addEventListener("click", function () {
 		let arrow = this.querySelector(".arrow");
@@ -61,13 +61,13 @@ function showSlides(slideshow, n) {
 	slides[current - 1].classList.add('active');
 	indicators.forEach(indicator => indicator.classList.remove('active'));
 	indicators[current - 1].classList.add('active');
-	updateSlideshowWidth(slideshowId);
+	updateSlideshowWidth(slideshow);
 }
 
-function updateSlideshowWidth(slideshowId) {
-	if (slideshowId !== '16' && slideshowId !== '17') return; // for now only essl/estofex and chmu have different widths
+function updateSlideshowWidth(slideshow) {
+	if (!slideshow.hasAttribute('data-dynamic-width')) return;
 
-	const slideshow = document.querySelector(`.slideshow[data-slideshow-id='${slideshowId}']`);
+	const slideshowId = slideshow.getAttribute('data-slideshow-id');
 	const indicatorsContainer = document.querySelector(`.indicators-container[data-slideshow-id='${slideshowId}']`);
 	const activeSlide = slideshow.querySelector('.slide.active .placeholder');
 

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -225,13 +225,12 @@ function updateIframeSrc() {
 
 function setIframeSrc(iframe) {
 	dlog(`Updating iframe src for ${iframe.id}`);
-	let url = iframe.getAttribute('data-src');
 	const mode = iframe.getAttribute('data-zoom-mode');
-	if (mode === 'eu') {
-		url = url.replace(iframe.getAttribute('data-zoom-desktop'), iframe.getAttribute('data-zoom-eu'));
-	} else if (window.innerWidth < 800) {
+	let url = mode === 'eu'
+		? iframe.getAttribute('data-src-eu')
+		: iframe.getAttribute('data-src-hr');
+	if (mode !== 'eu' && window.innerWidth < 800)
 		url = url.replace(iframe.getAttribute('data-zoom-desktop'), iframe.getAttribute('data-zoom-mobile'));
-	}
 	iframe.src = url;
 }
 

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -226,9 +226,28 @@ function updateIframeSrc() {
 function setIframeSrc(iframe) {
 	dlog(`Updating iframe src for ${iframe.id}`);
 	let url = iframe.getAttribute('data-src');
-	if (window.innerWidth < 800)
+	const mode = iframe.getAttribute('data-zoom-mode');
+	if (mode === 'eu') {
+		url = url.replace(iframe.getAttribute('data-zoom-desktop'), iframe.getAttribute('data-zoom-eu'));
+	} else if (window.innerWidth < 800) {
 		url = url.replace(iframe.getAttribute('data-zoom-desktop'), iframe.getAttribute('data-zoom-mobile'));
+	}
 	iframe.src = url;
+}
+
+function switchIframeZoom(frameId, btn) {
+	const mode = btn.getAttribute('data-mode');
+	const iframe = document.getElementById(frameId);
+	iframe.setAttribute('data-zoom-mode', mode);
+	setIframeSrc(iframe);
+
+	if (mode === 'eu') {
+		btn.setAttribute('data-mode', 'hr');
+		btn.textContent = '[HR]';
+	} else {
+		btn.setAttribute('data-mode', 'eu');
+		btn.textContent = '[EU]';
+	}
 }
 
 function hideOverlayOnDoubleTap() {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -44,21 +44,24 @@ async function addExpandableClickEventListener() {
 	});
 }
 
-let slidePage = [2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
-
 function plusSlides(slideshowId, n) {
-	showSlides(slideshowId, slidePage[slideshowId - 1] += n);
+	const slideshow = document.querySelector(`.slideshow[data-slideshow-id="${slideshowId}"]`);
+	const current = parseInt(slideshow.getAttribute('data-current-slide'));
+	showSlides(slideshowId, current + n);
 }
 
 function showSlides(slideshowId, n) {
-	const slides = document.querySelectorAll(`.slideshow[data-slideshow-id="${slideshowId}"] .slide`);
+	const slideshow = document.querySelector(`.slideshow[data-slideshow-id="${slideshowId}"]`);
+	const slides = slideshow.querySelectorAll('.slide');
 	const indicators = document.querySelectorAll(`.indicators-container[data-slideshow-id="${slideshowId}"] .indicator`);
-	if (n > slides.length) { slidePage[slideshowId - 1] = 1; }
-	if (n < 1) { slidePage[slideshowId - 1] = slides.length; }
+	let current = n;
+	if (current > slides.length) { current = 1; }
+	if (current < 1) { current = slides.length; }
+	slideshow.setAttribute('data-current-slide', current);
 	slides.forEach(slide => slide.classList.remove('active'));
-	slides[slidePage[slideshowId - 1] - 1].classList.add('active');
+	slides[current - 1].classList.add('active');
 	indicators.forEach(indicator => indicator.classList.remove('active'));
-	indicators[slidePage[slideshowId - 1] - 1].classList.add('active');
+	indicators[current - 1].classList.add('active');
 	updateSlideshowWidth(slideshowId);
 }
 

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -16,10 +16,10 @@ function scrollToElement(id) {
 }
 
 function addExpandableClickEventListener() {
-	var expandable = document.getElementsByClassName("expandable")[0];
+	const expandable = document.querySelector(".expandable");
 	expandable.addEventListener("click", function () {
 		let arrow = this.querySelector(".arrow");
-		var content = document.getElementsByClassName("links")[0];
+		const content = document.querySelector(".links");
 		if (content.style.maxHeight) {
 			content.style.maxHeight = null;
 			arrow.textContent = "▼";
@@ -87,7 +87,7 @@ window.addEventListener('load', function () {
 function showProgress() {
 	// Get all images on the page
 	const images = document.querySelectorAll('img');
-	const progressBar = document.getElementsByClassName('progress-bar')[0];
+	const progressBar = document.querySelector('.progress-bar');
 	let imagesLoaded = 0;
 
 	// Update progress bar
@@ -98,7 +98,7 @@ function showProgress() {
 		// Hide the progress bar when all images are loaded
 		if (imagesLoaded === images.length) {
 			setTimeout(() => {
-				document.getElementsByClassName('progress-container')[0].style.display = 'none';
+				document.querySelector('.progress-container').style.display = 'none';
 			}, 500); // Hide after a short delay
 		}
 	};
@@ -145,7 +145,7 @@ function addSwipeEvents() {
 		let endX = 0;
 		let endY = 0;
 		let isDragging = false;
-		const slideshowId = slideshow.getAttribute('data-slideshow-id');
+		const slideshowId = parseInt(slideshow.getAttribute('data-slideshow-id'));
 
 		// Prevent default drag behavior on images
 		const images = slideshow.querySelectorAll('img');

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -236,6 +236,8 @@ function switchIframeZoom(frameId, btn) {
 	setIframeSrc(iframe);
 	btn.setAttribute('data-mode', newMode);
 	btn.textContent = newMode === 'hr' ? '[HR]' : '[EU]';
+	const resetBtn = getResetButtonFromFrameId(frameId);
+	if (resetBtn.textContent === '[R]') resetBtn.style.display = 'none';
 }
 
 function hideOverlayOnDoubleTap() {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -238,18 +238,12 @@ function setIframeSrc(iframe) {
 }
 
 function switchIframeZoom(frameId, btn) {
-	const mode = btn.getAttribute('data-mode');
+	const newMode = btn.getAttribute('data-mode') === 'hr' ? 'eu' : 'hr';
 	const iframe = document.getElementById(frameId);
-	iframe.setAttribute('data-zoom-mode', mode);
+	iframe.setAttribute('data-zoom-mode', newMode);
 	setIframeSrc(iframe);
-
-	if (mode === 'eu') {
-		btn.setAttribute('data-mode', 'hr');
-		btn.textContent = '[HR]';
-	} else {
-		btn.setAttribute('data-mode', 'eu');
-		btn.textContent = '[EU]';
-	}
+	btn.setAttribute('data-mode', newMode);
+	btn.textContent = newMode === 'hr' ? '[HR]' : '[EU]';
 }
 
 function hideOverlayOnDoubleTap() {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -75,14 +75,6 @@ function updateSlideshowWidth(slideshow) {
 	indicatorsContainer.style.maxWidth = activeSlide.style.maxWidth;
 }
 
-window.addEventListener('load', function () {
-	const lazyImages = document.querySelectorAll('img.lazy');
-
-	lazyImages.forEach(img => {
-		img.src = img.getAttribute('data-src');
-		img.classList.remove('lazy');
-	});
-});
 
 function showProgress() {
 	// Get all images on the page
@@ -446,6 +438,10 @@ function dlog(...args) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+	document.querySelectorAll('img.lazy').forEach(img => {
+		img.src = img.getAttribute('data-src');
+		img.classList.remove('lazy');
+	});
 	showProgress();
 	addExpandableClickEventListener();
 	addSwipeEvents();

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -220,7 +220,7 @@ let previousWidth = 0;
 function updateIframeSrc() {
 	if (window.innerWidth === previousWidth) return;
 	previousWidth = window.innerWidth;
-	document.querySelectorAll('iframe[data-zoom-desktop]').forEach(iframe => setIframeSrc(iframe));
+	document.querySelectorAll('iframe[data-zoom-hr-desktop]').forEach(iframe => setIframeSrc(iframe));
 }
 
 function setIframeSrc(iframe) {
@@ -229,8 +229,11 @@ function setIframeSrc(iframe) {
 	let url = mode === 'eu'
 		? iframe.getAttribute('data-src-eu')
 		: iframe.getAttribute('data-src-hr');
-	if (mode !== 'eu' && window.innerWidth < 800)
-		url = url.replace(iframe.getAttribute('data-zoom-desktop'), iframe.getAttribute('data-zoom-mobile'));
+	if (window.innerWidth < 800) {
+		const desktopAttr = mode === 'eu' ? 'data-zoom-eu-desktop' : 'data-zoom-hr-desktop';
+		const mobileAttr = mode === 'eu' ? 'data-zoom-eu-mobile' : 'data-zoom-hr-mobile';
+		url = url.replace(iframe.getAttribute(desktopAttr), iframe.getAttribute(mobileAttr));
+	}
 	iframe.src = url;
 }
 

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -123,16 +123,12 @@ function showProgress() {
 	});
 }
 
-function handleSwipe(slideshowId, startX, endX) {
+function handleSwipe(slideshow, startX, endX) {
 	const threshold = 50;
 	const distance = endX - startX;
-
 	if (Math.abs(distance) > threshold) {
-		if (distance > 0) {
-			plusSlides(slideshowId, -1); // swipe right
-		} else {
-			plusSlides(slideshowId, 1); // swipe left
-		}
+		const current = parseInt(slideshow.getAttribute('data-current-slide'));
+		showSlides(slideshow, current + (distance > 0 ? -1 : 1));
 	}
 }
 
@@ -145,7 +141,6 @@ function addSwipeEvents() {
 		let endX = 0;
 		let endY = 0;
 		let isDragging = false;
-		const slideshowId = parseInt(slideshow.getAttribute('data-slideshow-id'));
 
 		// Prevent default drag behavior on images
 		const images = slideshow.querySelectorAll('img');
@@ -177,7 +172,7 @@ function addSwipeEvents() {
 
 				// Only trigger swipe if horizontal movement is greater than vertical movement (prevent swipe on scroll up or down)
 				if (Math.abs(deltaX) > Math.abs(deltaY)) {
-					handleSwipe(slideshowId, startX, endX);
+					handleSwipe(slideshow, startX, endX);
 				}
 			}
 		});
@@ -205,7 +200,7 @@ function addSwipeEvents() {
 
 				// Only trigger swipe if horizontal movement is greater than vertical movement (prevent swipe on scroll up or down)
 				if (Math.abs(deltaX) > Math.abs(deltaY)) {
-					handleSwipe(slideshowId, startX, endX);
+					handleSwipe(slideshow, startX, endX);
 				}
 				isDragging = false;
 			}

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -222,45 +222,18 @@ function addSwipeEvents() {
 
 let previousWidth = 0;
 
-let zoomMap = new Map();
-zoomMap.set('windy', [ '&zoom=7', '&zoom=6' ]);
-zoomMap.set('blitzortung', [ '#6/', '#5/' ]);
-zoomMap.set('weatherAndRadar', [ '&zoom=7.2', '&zoom=6.8' ]);
-zoomMap.set('rainViewer', [ ',6.3&', ',5.8&' ]);
-zoomMap.set('ventussky', [ ';6&', ';6&' ]);
-
 function updateIframeSrc() {
-	if (window.innerWidth !== previousWidth) {
-		previousWidth = window.innerWidth;
-		setIframeSrc('windy');
-		setIframeSrc('blitzortung');
-		setIframeSrc('weatherAndRadar');
-		setIframeSrc('rainViewer');
-		setIframeSrc('ventussky');
-	}
+	if (window.innerWidth === previousWidth) return;
+	previousWidth = window.innerWidth;
+	document.querySelectorAll('iframe[data-zoom-desktop]').forEach(iframe => setIframeSrc(iframe));
 }
 
-function setIframeSrc(iframeId) {
-	dlog(`Updating iframe src for ${iframeId}`);
-
-	const iframe = document.getElementById(iframeId);
-	if (iframe) {
-		let values = zoomMap.get(iframeId);
-		let url = iframe.getAttribute('data-src');
-
-		if (values && values.length > 0) {
-			let zoomOld = values[0];
-			let zoomNew = values[1];
-
-			if (window.innerWidth < 800)
-				url = url.replace(zoomOld, zoomNew);
-		}
-
-		iframe.src = url;
-	}
-	else {
-		dlog(`${iframeId} not found, skipping updateIframeSrc for ${iframeId}`);
-	}
+function setIframeSrc(iframe) {
+	dlog(`Updating iframe src for ${iframe.id}`);
+	let url = iframe.getAttribute('data-src');
+	if (window.innerWidth < 800)
+		url = url.replace(iframe.getAttribute('data-zoom-desktop'), iframe.getAttribute('data-zoom-mobile'));
+	iframe.src = url;
 }
 
 function hideOverlayOnDoubleTap() {
@@ -371,7 +344,7 @@ function setResetButtonToReset(resetFrame) {
 
 function resetIframe(frameId) {
 	dlog(`Resetting iframe: ${frameId}`);
-	setIframeSrc(frameId);
+	setIframeSrc(document.getElementById(frameId));
 
 	const resetFrame = getResetButtonFromFrameId(frameId);
 	resetFrame.style.display = 'none';

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -379,16 +379,16 @@ function resetIframe(frameId) {
 }
 
 function getResetButtonFromFrameId(frameId) {
-	return document.getElementById('reset' + String(frameId).charAt(0).toUpperCase() + String(frameId).slice(1) + 'Frame');
+	return document.querySelector(`a[data-frame-id="${frameId}"]`);
 }
 
 function getResetButtonFromOverlayId(overlayId) {
-	return document.getElementById(overlayId.replace('overlay', 'reset'));
+	const frameId = document.getElementById(overlayId).getAttribute('data-frame-id');
+	return getResetButtonFromFrameId(frameId);
 }
 
 function getFrameIdFromResetButtonId(resetFrameId) {
-	let name = resetFrameId.replace('reset', '').replace('Frame', '');
-	return String(name).charAt(0).toLowerCase() + String(name).slice(1);
+	return document.getElementById(resetFrameId).getAttribute('data-frame-id');
 }
 
 function setEsslImgSrc(tryCount = 1) {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -415,31 +415,20 @@ function GetLastInit() {
 };
 
 function DTGFromDateInHours(mydate) {
-	result = mydate.getUTCFullYear().toString() + pad(mydate.getUTCMonth() + 1, 2) + pad(mydate.getUTCDate(), 2) + pad(mydate.getUTCHours(), 2);
+	const result = mydate.getUTCFullYear().toString() + pad(mydate.getUTCMonth() + 1, 2) + pad(mydate.getUTCDate(), 2) + pad(mydate.getUTCHours(), 2);
 	return result;
 };
 
 function EndValue(mydate) {
-	result = mydate.getUTCFullYear().toString() + pad(mydate.getUTCMonth() + 1, 2) + pad(mydate.getUTCDate(), 2) + "06";
+	const result = mydate.getUTCFullYear().toString() + pad(mydate.getUTCMonth() + 1, 2) + pad(mydate.getUTCDate(), 2) + "06";
 	return result;
 };
 
 function pad(n, width, z) {
-	z = z || '0';
-	n = n + '';
-	return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
+	return String(n).padStart(width, z || '0');
 };
 
-let isDebugEnabled = false;
-
-function getUrlParameter(name) {
-	const urlParams = new URLSearchParams(window.location.search);
-	return urlParams.get(name);
-}
-
-if (getUrlParameter('debug') === '1') {
-	isDebugEnabled = true;
-}
+const isDebugEnabled = new URLSearchParams(window.location.search).get('debug') === '1';
 
 function dlog(...args) {
 	if (isDebugEnabled)

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -46,12 +46,11 @@ async function addExpandableClickEventListener() {
 
 function plusSlides(slideshowId, n) {
 	const slideshow = document.querySelector(`.slideshow[data-slideshow-id="${slideshowId}"]`);
-	const current = parseInt(slideshow.getAttribute('data-current-slide'));
-	showSlides(slideshowId, current + n);
+	showSlides(slideshow, parseInt(slideshow.getAttribute('data-current-slide')) + n);
 }
 
-function showSlides(slideshowId, n) {
-	const slideshow = document.querySelector(`.slideshow[data-slideshow-id="${slideshowId}"]`);
+function showSlides(slideshow, n) {
+	const slideshowId = slideshow.getAttribute('data-slideshow-id');
 	const slides = slideshow.querySelectorAll('.slide');
 	const indicators = document.querySelectorAll(`.indicators-container[data-slideshow-id="${slideshowId}"] .indicator`);
 	let current = n;
@@ -66,7 +65,7 @@ function showSlides(slideshowId, n) {
 }
 
 function updateSlideshowWidth(slideshowId) {
-	if (slideshowId !== 16 && slideshowId !== 17) return; // for now only essl/estofex and chmu have different widths
+	if (slideshowId !== '16' && slideshowId !== '17') return; // for now only essl/estofex and chmu have different widths
 
 	const slideshow = document.querySelector(`.slideshow[data-slideshow-id='${slideshowId}']`);
 	const indicatorsContainer = document.querySelector(`.indicators-container[data-slideshow-id='${slideshowId}']`);

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -21,22 +21,25 @@ const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1)
 document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
 i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
-e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),
+e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),
 e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
 e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
 document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
 ;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
-document.querySelectorAll("iframe[data-zoom-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
-dlog(`Updating iframe src for ${e.id}`);let t=e.getAttribute("data-src")
-;window.innerWidth<800&&(t=t.replace(e.getAttribute("data-zoom-desktop"),e.getAttribute("data-zoom-mobile"))),e.src=t}
-function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{
-e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
-;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,s=Math.abs(t-r),a=Math.abs(i-n);s<10&&a<10&&(o.style.opacity="0.6",
+document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
+dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
+;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
+const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
+;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
+const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
+t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]"}function hideOverlayOnDoubleTap(){
+document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
+const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
+setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
+1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,a=Math.abs(t-r),s=Math.abs(i-n);a<10&&s<10&&(o.style.opacity="0.6",
 clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -55,10 +58,10 @@ const t=document.getElementById("essl");if(!t)return void dlog("essl img not fou
 ;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
 ;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
 ;dlog("dtg: "+r),dlog("end: "+i)
-;let s=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function a(){
-if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
+;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function s(){
+if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",s),setEsslImgSrc(e+1);else{
 dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=s}function GetLastInit(){let e=new Date
+t.parentNode.appendChild(e)}}t.removeEventListener("error",s),t.addEventListener("error",s),t.src=a}function GetLastInit(){let e=new Date
 ;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -1,28 +1,29 @@
 function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
-;t&&t.scrollIntoView({behavior:"smooth",block:"start"})}async function addExpandableClickEventListener(){
-document.getElementsByClassName("expandable")[0].addEventListener("click",function(){let e=this.querySelector(".arrow")
-;var t=document.getElementsByClassName("links")[0];t.style.maxHeight?(t.style.maxHeight=null,
+;t&&t.scrollIntoView({behavior:"smooth",block:"start"})}function addExpandableClickEventListener(){
+document.querySelector(".expandable").addEventListener("click",function(){let e=this.querySelector(".arrow")
+;const t=document.querySelector(".links");t.style.maxHeight?(t.style.maxHeight=null,
 e.textContent="▼"):(t.style.maxHeight=t.scrollHeight+"px",e.textContent="▲",setTimeout(()=>{
 document.documentElement.style.scrollBehavior="auto",document.body.style.scrollBehavior="auto",scrollToElement("links"),setTimeout(()=>{
-document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}
-let slidePage=[2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1];function plusSlides(e,t){showSlides(e,slidePage[e-1]+=t)}function showSlides(e,t){
-const o=document.querySelectorAll(`.slideshow[data-slideshow-id="${e}"] .slide`),n=document.querySelectorAll(`.indicators-container[data-slideshow-id="${e}"] .indicator`)
-;t>o.length&&(slidePage[e-1]=1),t<1&&(slidePage[e-1]=o.length),o.forEach(e=>e.classList.remove("active")),
-o[slidePage[e-1]-1].classList.add("active"),n.forEach(e=>e.classList.remove("active")),n[slidePage[e-1]-1].classList.add("active"),
-updateSlideshowWidth(e)}function updateSlideshowWidth(e){if(16!==e&&17!==e)return
-;const t=document.querySelector(`.slideshow[data-slideshow-id='${e}']`),o=document.querySelector(`.indicators-container[data-slideshow-id='${e}']`),n=t.querySelector(".slide.active .placeholder")
-;t.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
-const e=document.querySelectorAll("img"),t=document.getElementsByClassName("progress-bar")[0];let o=0;const n=()=>{const n=o/e.length*100
-;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.getElementsByClassName("progress-container")[0].style.display="none"},500)}
-;e.forEach(e=>{e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),
-e.removeAttribute("src"),n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t
-;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{
-let t=0,o=0,n=0,r=0,s=!1;const a=e.getAttribute("data-slideshow-id");e.querySelectorAll("img").forEach(e=>{
+document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}function plusSlides(e,t){
+const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
+function showSlides(e,t){
+const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
+;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
+;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
+;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
+const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar");let o=0;const n=()=>{const n=o/e.length*100
+;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.querySelector(".progress-container").style.display="none"},500)};e.forEach(e=>{
+e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
+n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}
+function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1
+;const i=parseInt(e.getAttribute("data-slideshow-id"));e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
 s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
-e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(a,t,n)}}),
+e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(i,t,n)}}),
 e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const i=n-t,l=r-o;Math.abs(i)>Math.abs(l)&&handleSwipe(a,t,n),s=!1}}),
+e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(i,t,n),s=!1}}),
 e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}window.addEventListener("load",function(){
 document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})})
 ;let previousWidth=0,zoomMap=new Map;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
@@ -35,7 +36,7 @@ document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListene
 const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
 setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
 1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,a=Math.abs(t-r),i=Math.abs(s-n);a<10&&i<10&&(o.style.opacity="0.6",
+;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
 clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -47,17 +48,16 @@ restoreOverlay(getFrameIdFromResetButtonId(t.id))}),t.textContent="[X]"}function
 dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
 dlog(`Resetting iframe: ${e}`),setIframeSrc(e);const t=getResetButtonFromFrameId(e);t.style.display="none",setResetButtonToExit(t)}
-function getResetButtonFromFrameId(e){return document.getElementById("reset"+String(e).charAt(0).toUpperCase()+String(e).slice(1)+"Frame")}
-function getResetButtonFromOverlayId(e){return document.getElementById(e.replace("overlay","reset"))}
-function getFrameIdFromResetButtonId(e){let t=e.replace("reset","").replace("Frame","")
-;return String(t).charAt(0).toLowerCase()+String(t).slice(1)}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
+function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
+return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
+return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
 ;if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit();e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
 ;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
 ;dlog("dtg: "+r),dlog("end: "+s)
-;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function i(){
-if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",i),setEsslImgSrc(e+1);else{
+;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-t.parentNode.appendChild(e)}}t.removeEventListener("error",i),t.addEventListener("error",i),t.src=a}function GetLastInit(){let e=new Date
+t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
 ;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 function DTGFromDateInHours(e){
 return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2),result}

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -8,8 +8,8 @@ document.documentElement.style.scrollBehavior="smooth",document.body.style.scrol
 const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 function showSlides(e,t){
 const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
-n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
+;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
 function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 ;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 ;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -18,28 +18,28 @@ const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar
 e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
+document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
-i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
-e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),
-e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
-document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
-;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
+s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
+e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),
+e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
+e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
+e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}let previousWidth=0;function updateIframeSrc(){
+window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
 ;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
 const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
 ;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
 const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
-t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]"}function hideOverlayOnDoubleTap(){
-document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
-const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
-1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,a=Math.abs(t-r),s=Math.abs(i-n);a<10&&s<10&&(o.style.opacity="0.6",
+t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getResetButtonFromFrameId(e)
+;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
+let t=0;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
+setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
+;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
 clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -56,16 +56,17 @@ function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(documen
 function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){
 const t=document.getElementById("essl");if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit()
 ;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
-;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
-;dlog("dtg: "+r),dlog("end: "+i)
-;let a=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function s(){
-if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",s),setEsslImgSrc(e+1);else{
+;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
+;dlog("dtg: "+r),dlog("end: "+s)
+;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-t.parentNode.appendChild(e)}}t.removeEventListener("error",s),t.addEventListener("error",s),t.src=a}function GetLastInit(){let e=new Date
+t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
 ;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
-isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{showProgress(),addExpandableClickEventListener(),
-addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
+isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
+e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
+updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
 clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -8,35 +8,35 @@ document.documentElement.style.scrollBehavior="smooth",document.body.style.scrol
 const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 function showSlides(e,t){
 const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
-n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
+n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
 function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 ;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 ;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
 const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar");let o=0;const n=()=>{const n=o/e.length*100
 ;t.style.width=n+"%",o===e.length&&setTimeout(()=>{document.querySelector(".progress-container").style.display="none"},500)};e.forEach(e=>{
 e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
-n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;Math.abs(n)>50&&plusSlides(e,n>0?-1:1)}
-function addSwipeEvents(){document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1
-;const i=parseInt(e.getAttribute("data-slideshow-id"));e.querySelectorAll("img").forEach(e=>{
+n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
+const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
+document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{t=e.touches[0].clientX,o=e.touches[0].clientY,
-s=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(s=!0)}),
-e.addEventListener("touchend",()=>{if(s){const e=n-t,s=r-o;Math.abs(e)>Math.abs(s)&&handleSwipe(i,t,n)}}),
-e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",e=>{if(s){n=e.clientX,r=e.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(i,t,n),s=!1}}),
-e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}window.addEventListener("load",function(){
-document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})})
-;let previousWidth=0,zoomMap=new Map;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
-setIframeSrc("windy"),setIframeSrc("blitzortung"),setIframeSrc("weatherAndRadar"),setIframeSrc("rainViewer"),setIframeSrc("ventussky"))}
-function setIframeSrc(e){dlog(`Updating iframe src for ${e}`);const t=document.getElementById(e);if(t){
-let o=zoomMap.get(e),n=t.getAttribute("data-src");if(o&&o.length>0){let e=o[0],t=o[1];window.innerWidth<800&&(n=n.replace(e,t))}t.src=n
-}else dlog(`${e} not found, skipping updateIframeSrc for ${e}`)}function hideOverlayOnDoubleTap(){
-document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchend",o=>{
-const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-setResetButtonToExit(t),o.preventDefault()}t=n});const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{
-1===e.touches.length&&(r=e.touches[0].clientX,n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
-;const t=e.changedTouches[0].clientX,s=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(s-n);i<10&&a<10&&(o.style.opacity="0.6",
+i=!1}),e.addEventListener("touchmove",e=>{n=e.touches[0].clientX,r=e.touches[0].clientY,Math.abs(n-t)>Math.abs(r-o)&&(i=!0)}),
+e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),
+e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
+e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}window.addEventListener("load",function(){
+document.querySelectorAll("img.lazy").forEach(e=>{e.src=e.getAttribute("data-src"),e.classList.remove("lazy")})});let previousWidth=0
+;function updateIframeSrc(){window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
+document.querySelectorAll("iframe[data-zoom-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
+dlog(`Updating iframe src for ${e.id}`);let t=e.getAttribute("data-src")
+;window.innerWidth<800&&(t=t.replace(e.getAttribute("data-zoom-desktop"),e.getAttribute("data-zoom-mobile"))),e.src=t}
+function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0;e.addEventListener("dblclick",()=>{
+e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+e.addEventListener("touchend",o=>{const n=(new Date).getTime(),r=n-t;if(r>0&&r<200){e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),o.preventDefault()}t=n})
+;const o=e.querySelector(".hint");let n=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+n=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!o)return
+;const t=e.changedTouches[0].clientX,i=e.changedTouches[0].clientY,s=Math.abs(t-r),a=Math.abs(i-n);s<10&&a<10&&(o.style.opacity="0.6",
 clearTimeout(o._hideTimer),o._hideTimer=setTimeout(()=>{o.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -47,26 +47,22 @@ function restoreOverlay(e){dlog(`restoreOverlay: ${e}`)
 restoreOverlay(getFrameIdFromResetButtonId(t.id))}),t.textContent="[X]"}function setResetButtonToReset(e){
 dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
-dlog(`Resetting iframe: ${e}`),setIframeSrc(e);const t=getResetButtonFromFrameId(e);t.style.display="none",setResetButtonToExit(t)}
-function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
-return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
-return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){const t=document.getElementById("essl")
-;if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit();e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
-;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),s=EndValue(n)
-;dlog("dtg: "+r),dlog("end: "+s)
-;let i=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${s}.png`;function a(){
+dlog(`Resetting iframe: ${e}`),setIframeSrc(document.getElementById(e));const t=getResetButtonFromFrameId(e);t.style.display="none",
+setResetButtonToExit(t)}function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}
+function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}
+function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function setEsslImgSrc(e=1){
+const t=document.getElementById("essl");if(!t)return void dlog("essl img not found, skipping setEsslImgSrc");let o=GetLastInit()
+;e>1&&o.setUTCHours(o.getUTCHours()-12*(e-1))
+;let n=new Date(Date.UTC(o.getUTCFullYear(),o.getUTCMonth(),o.getUTCDate()+(12===o.getUTCHours()?3:2),0,0,0,0)),r=DTGFromDateInHours(o),i=EndValue(n)
+;dlog("dtg: "+r),dlog("end: "+i)
+;let s=`https://www.stormforecast.eu/map_images/models/archamos/${r.slice(0,6)}/${r}/combi_paramcombi24_${r}_${i}.png`;function a(){
 if(e<5)dlog(`Image load failed, try attempt ${e} with dtg: ${r}`),t.removeEventListener("error",a),setEsslImgSrc(e+1);else{
 dlog("Image load failed after 5 attempts");const e=document.createElement("span");e.innerHTML="Nema prognoze za traženi period",
-t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=i}function GetLastInit(){let e=new Date
+t.parentNode.appendChild(e)}}t.removeEventListener("error",a),t.addEventListener("error",a),t.src=s}function GetLastInit(){let e=new Date
 ;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
-function DTGFromDateInHours(e){
-return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2),result}
-function EndValue(e){return result=e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06",result}
-function pad(e,t,o){return o=o||"0",(e+="").length>=t?e:new Array(t-e.length+1).join(o)+e}zoomMap.set("windy",["&zoom=7","&zoom=6"]),
-zoomMap.set("blitzortung",["#6/","#5/"]),zoomMap.set("weatherAndRadar",["&zoom=7.2","&zoom=6.8"]),
-zoomMap.set("rainViewer",[",6.3&",",5.8&"]),zoomMap.set("ventussky",[";6&",";6&"]);let isDebugEnabled=!1;function getUrlParameter(e){
-return new URLSearchParams(window.location.search).get(e)}function dlog(...e){isDebugEnabled&&console.log(...e)}
-"1"===getUrlParameter("debug")&&(isDebugEnabled=!0),document.addEventListener("DOMContentLoaded",()=>{showProgress(),
-addExpandableClickEventListener(),addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),
-window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
-updateHintText()},200)});
+function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
+function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
+return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
+isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{showProgress(),addExpandableClickEventListener(),
+addSwipeEvents(),updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),setEsslImgSrc()}),window.addEventListener("resize",()=>{
+clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -83,7 +83,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.arso.gov.si/met/sl/weather/observ/radar/" target="_blank" rel="nofollow">meteo.si</a>
-					<div class="slideshow placeholder" data-slideshow-id="6" style="max-width: 821px; aspect-ratio: 821 / 660; ">
+					<div class="slideshow placeholder" data-slideshow-id="6" data-current-slide="1" style="max-width: 821px; aspect-ratio: 821 / 660; ">
 						<div class="slide fade active">
 							<img src="https://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm-anim.gif?nocache" />
 						</div>
@@ -174,7 +174,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=puntijarka&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Puntijarka</a>
-					<div class="slideshow placeholder" data-slideshow-id="8" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="8" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_puntijarka.gif" />
 						</div>
@@ -195,7 +195,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=bilogora&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Bilogora</a>
-					<div class="slideshow placeholder" data-slideshow-id="9" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="9" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_bilogora.gif" />
 						</div>
@@ -216,7 +216,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=gradiste&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Gradište</a>
-					<div class="slideshow placeholder" data-slideshow-id="10" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="10" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_gradiste.gif" />
 						</div>
@@ -237,7 +237,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=goli&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Goli</a>
-					<div class="slideshow placeholder" data-slideshow-id="11" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="11" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_goli.gif" />
 						</div>
@@ -258,7 +258,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=debeljak&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Debeljak</a>
-					<div class="slideshow placeholder" data-slideshow-id="12" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="12" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_debeljak.gif" />
 						</div>
@@ -279,7 +279,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=uljenje&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Uljenje</a>
-					<div class="slideshow placeholder" data-slideshow-id="13" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="13" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_uljenje.gif" />
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -40,9 +40,9 @@
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager"
-								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&"
-								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" frameborder="0" data-zoom-desktop=";6&" data-zoom-mobile=";6&"
+								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off"
+								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -59,9 +59,9 @@
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy"
-								data-src-hr="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&"
-								data-src-eu="https://www.rainviewer.com/map.html?loc=48.0,10.0,4.0&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&"
+								data-src-hr="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1"
+								data-src-eu="https://www.rainviewer.com/map.html?loc=48.0,10.0,4.0&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -78,9 +78,9 @@
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy"
-								data-src-hr="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8"
-								data-src-eu="https://radar.wo-cloud.com/pwa/?center=48.0,10.0&zoom=5.0&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8"
+								data-src-hr="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true"
+								data-src-eu="https://radar.wo-cloud.com/pwa/?center=48.0,10.0&zoom=5.0&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true"></iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -35,7 +35,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('ventussky', this)">[EU]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventussky', this)">[HR]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
@@ -55,7 +55,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('rainViewer', this)">[EU]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('rainViewer', this)">[HR]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
@@ -75,7 +75,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('weatherAndRadar', this)">[EU]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -40,7 +40,9 @@
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&" data-zoom-eu=";4&" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager"
+								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&"
+								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -57,7 +59,9 @@
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&" data-zoom-eu=",4&" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy"
+								data-src-hr="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&"
+								data-src-eu="https://www.rainviewer.com/map.html?loc=48.0,10.0,4.0&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -74,7 +78,9 @@
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8" data-zoom-eu="&zoom=4" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy"
+								data-src-hr="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8"
+								data-src-eu="https://radar.wo-cloud.com/pwa/?center=48.0,10.0&zoom=5.0&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -40,9 +40,10 @@
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" frameborder="0" data-zoom-desktop=";6&" data-zoom-mobile=";6&"
-								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off"
-								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" frameborder="0"
+								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-hr-desktop=";6&" data-zoom-hr-mobile=";6&"
+								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off" data-zoom-eu-desktop=";4&" data-zoom-eu-mobile=";3&">
+						</iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -59,9 +60,10 @@
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&"
-								data-src-hr="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1"
-								data-src-eu="https://www.rainviewer.com/map.html?loc=48.0,10.0,4.0&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" frameborder="0"
+								data-src-hr="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-hr-desktop=",6.3&" data-zoom-hr-mobile=",5.8&"
+								data-src-eu="https://www.rainviewer.com/map.html?loc=48.0,10.0,4.0&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-eu-desktop=",4.0&" data-zoom-eu-mobile=",3.2&">
+						</iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -78,9 +80,10 @@
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8"
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-hr-desktop="&zoom=7.2" data-zoom-hr-mobile="&zoom=6.8" data-zoom-eu-desktop="&zoom=5.0" data-zoom-eu-mobile="&zoom=4.0"
 								data-src-hr="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true"
-								data-src-eu="https://radar.wo-cloud.com/pwa/?center=48.0,10.0&zoom=5.0&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true"></iframe>
+								data-src-eu="https://radar.wo-cloud.com/pwa/?center=48.0,10.0&zoom=5.0&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true">
+						</iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -36,11 +36,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a class="right" id="resetVentusskyFrame" style="display:none">[X]</a>
+						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
-						<div class="overlay" id="overlayVentusskyFrame">
+						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -52,11 +52,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a class="right" id="resetRainViewerFrame" style="display:none">[X]</a>
+						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
-						<div class="overlay" id="overlayRainViewerFrame">
+						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -68,11 +68,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
-						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
+						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
-						<div class="overlay" id="overlayWeatherAndRadarFrame">
+						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -39,7 +39,7 @@
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -55,7 +55,7 @@
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&" frameborder="0"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -71,7 +71,7 @@
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -35,11 +35,12 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('ventussky', this)">[EU]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-desktop=";6&" data-zoom-mobile=";6&" data-zoom-eu=";4&" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -51,11 +52,12 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('rainViewer', this)">[EU]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" data-zoom-desktop=",6.3&" data-zoom-mobile=",5.8&" data-zoom-eu=",4&" frameborder="0"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame" data-frame-id="rainViewer">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -67,11 +69,12 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('weatherAndRadar', this)">[EU]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" data-zoom-desktop="&zoom=7.2" data-zoom-mobile="&zoom=6.8" data-zoom-eu="&zoom=4" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/index.html
+++ b/src/index.html
@@ -135,7 +135,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('windy', this)">[EU]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('windy', this)">[HR]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
@@ -202,7 +202,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('blitzortung', this)">[EU]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>

--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Hrvatska</a>
-					<div class="slideshow placeholder" data-slideshow-id="1" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="1" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/radar/latest_hr.webp" class="lazy" />
 						</div>
@@ -60,7 +60,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Hrvatska</a>
-					<div class="slideshow placeholder" data-slideshow-id="2" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="2" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/sat/latest_vis_hr.webp" class="lazy" />
 						</div>
@@ -85,7 +85,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Europa</a>
-					<div class="slideshow placeholder" data-slideshow-id="3" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="3" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/radar/latest_eu2.webp" class="lazy" />
 						</div>
@@ -110,7 +110,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Europa</a>
-					<div class="slideshow placeholder" data-slideshow-id="4" style="aspect-ratio: 880 / 640;">
+					<div class="slideshow placeholder" data-slideshow-id="4" data-current-slide="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/sat/latest_vis_eu2.webp" class="lazy" />
 						</div>
@@ -151,7 +151,7 @@
 			<tr>
 				<td align="center">
 					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | kompozit</a>
-					<div class="slideshow placeholder" data-slideshow-id="7" style="max-width: 720px; aspect-ratio: 720 / 751;">
+					<div class="slideshow placeholder" data-slideshow-id="7" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_kompozit.gif" />
 						</div>
@@ -171,7 +171,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="15" style="max-width: 768px;">
+					<div class="slideshow" data-slideshow-id="15" data-current-slide="1" style="max-width: 768px;">
 						<div class="slide fade active">
 							<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel.fr | Temperatura </a>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
@@ -213,7 +213,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="16">
+					<div class="slideshow" data-slideshow-id="16" data-current-slide="1">
 						<div class="slide fade active">
 							<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
 							<div class="placeholder" style="max-width: 900px; aspect-ratio: 900 / 600; ">
@@ -256,7 +256,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="5" style="max-width: 768px;">
+					<div class="slideshow" data-slideshow-id="5" data-current-slide="1" style="max-width: 768px;">
 						<div class="slide fade active">
 							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
@@ -300,7 +300,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="17" style="max-width: 760px;">
+					<div class="slideshow" data-slideshow-id="17" data-current-slide="1" style="max-width: 760px;">
 						<div class="slide fade active">
 							<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 493; overflow: hidden;">
@@ -360,7 +360,7 @@
 			<!--
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="14">
+					<div class="slideshow" data-slideshow-id="14" data-current-slide="1">
 						<div class="slide fade active">
 							<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">meteoblue | Prognoza | Zagreb</a>
 							<div class="placeholder" style="aspect-ratio: 1152 / 963;">

--- a/src/index.html
+++ b/src/index.html
@@ -135,11 +135,12 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('windy', this)">[EU]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6" frameborder="0"></iframe>
+						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6" data-zoom-eu="&zoom=4" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -198,11 +199,12 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="left zoom-btn" data-mode="eu" onclick="switchIframeZoom('blitzortung', this)">[EU]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/" frameborder="0"></iframe>
+						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/" data-zoom-eu="#4/" frameborder="0"></iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/index.html
+++ b/src/index.html
@@ -136,11 +136,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a class="right" id="resetWindyFrame" style="display:none">[X]</a>
+						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" frameborder="0"></iframe>
-						<div class="overlay" id="overlayWindyFrame">
+						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -199,11 +199,11 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
-						<a class="right" id="resetBlitzortungFrame" style="display:none">[X]</a>
+						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" frameborder="0"></iframe>
-						<div class="overlay" id="overlayBlitzortungFrame">
+						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>

--- a/src/index.html
+++ b/src/index.html
@@ -140,7 +140,9 @@
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6" data-zoom-eu="&zoom=4" frameborder="0"></iframe>
+						<iframe id="windy" loading="lazy"
+								data-src-hr="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6"
+								data-src-eu="https://embed.windy.com/embed2.html?lat=48.0&lon=10.00&zoom=5&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -204,7 +206,9 @@
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/" data-zoom-eu="#4/" frameborder="0"></iframe>
+						<iframe id="blitzortung" loading="lazy"
+								data-src-hr="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/"
+								data-src-eu="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#4/48.0/10.0" frameborder="0"></iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/index.html
+++ b/src/index.html
@@ -140,9 +140,9 @@
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy"
-								data-src-hr="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6"
-								data-src-eu="https://embed.windy.com/embed2.html?lat=48.0&lon=10.00&zoom=5&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" frameborder="0"></iframe>
+						<iframe id="windy" loading="lazy" frameborder="0" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6"
+								data-src-hr="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1"
+								data-src-eu="https://embed.windy.com/embed2.html?lat=48.0&lon=10.00&zoom=5&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1"></iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -206,9 +206,9 @@
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy"
-								data-src-hr="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/"
-								data-src-eu="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#4/48.0/10.0" frameborder="0"></iframe>
+						<iframe id="blitzortung" loading="lazy" frameborder="0" data-zoom-desktop="#6/" data-zoom-mobile="#5/"
+								data-src-hr="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5"
+								data-src-eu="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#4/48.0/10.0"></iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/index.html
+++ b/src/index.html
@@ -213,7 +213,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="16" data-current-slide="1">
+					<div class="slideshow" data-slideshow-id="16" data-current-slide="1" data-dynamic-width>
 						<div class="slide fade active">
 							<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
 							<div class="placeholder" style="max-width: 900px; aspect-ratio: 900 / 600; ">
@@ -300,7 +300,7 @@
 
 			<tr>
 				<td align="center">
-					<div class="slideshow" data-slideshow-id="17" data-current-slide="1" style="max-width: 760px;">
+					<div class="slideshow" data-slideshow-id="17" data-current-slide="1" data-dynamic-width style="max-width: 760px;">
 						<div class="slide fade active">
 							<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 493; overflow: hidden;">

--- a/src/index.html
+++ b/src/index.html
@@ -140,9 +140,10 @@
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy" frameborder="0" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6"
-								data-src-hr="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1"
-								data-src-eu="https://embed.windy.com/embed2.html?lat=48.0&lon=10.00&zoom=5&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1"></iframe>
+						<iframe id="windy" loading="lazy" frameborder="0"
+								data-src-hr="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-hr-desktop="&zoom=7" data-zoom-hr-mobile="&zoom=6"
+								data-src-eu="https://embed.windy.com/embed2.html?lat=48.0&lon=10.00&zoom=5&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-eu-desktop="&zoom=5" data-zoom-eu-mobile="&zoom=3">
+						</iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -206,9 +207,10 @@
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy" frameborder="0" data-zoom-desktop="#6/" data-zoom-mobile="#5/"
-								data-src-hr="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5"
-								data-src-eu="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#4/48.0/10.0"></iframe>
+						<iframe id="blitzortung" loading="lazy" frameborder="0"
+								data-src-hr="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-hr-desktop="#6/" data-zoom-hr-mobile="#5/"
+								data-src-eu="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#4/48.0/10.0" data-zoom-eu-desktop="#4/" data-zoom-eu-mobile="#2.5/">
+						</iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/index.html
+++ b/src/index.html
@@ -139,7 +139,7 @@
 						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" frameborder="0"></iframe>
+						<iframe id="windy" loading="lazy" data-src="https://embed.windy.com/embed2.html?lat=44.5&lon=16.56&zoom=7&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat=45.798&detailLon=15.936&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1" data-zoom-desktop="&zoom=7" data-zoom-mobile="&zoom=6" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWindyFrame" data-frame-id="windy">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -202,7 +202,7 @@
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" frameborder="0"></iframe>
+						<iframe id="blitzortung" loading="lazy" data-src="https://map.blitzortung.org/index.php?interactive=1&NavigationControl=1&FullScreenControl=0&Cookies=0&InfoDiv=0&MenuButtonDiv=0&ScaleControl=0&CirclesRangeValue=1&LinksCheckboxChecked=0&LinksRangeValue=0&MapStyle=1&MapStyleRangeValue=3&Advertisment=0#6/44.5/16.5" data-zoom-desktop="#6/" data-zoom-mobile="#5/" frameborder="0"></iframe>
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>


### PR DESCRIPTION
- Added [HR]/[EU] toggle button to all interactive iframes (Windy, Blitzortung, Ventussky, Rain Viewer, Weather&Radar), showing the current active zoom state
- Toggle button switches between Croatia-centered and Europe-centered map views, each with separate desktop and mobile zoom levels
- Iframe zoom URLs stored as full data-src-hr / data-src-eu attributes, making lat/lon/zoom differences explicit and easy to edit
- Zoom attributes renamed to data-zoom-hr-desktop / data-zoom-hr-mobile / data-zoom-eu-desktop / data-zoom-eu-mobile for consistency
- Clicking the zoom toggle hides the [R] reset button if visible (no longer relevant after a mode change)
- Fixed progress bar hiding prematurely on mobile — lazy images now have their src set before progress tracking begins, so all images are counted

Optimizations/cleanup:
- Moved slideshow current page state from a JS array to data-current-slide HTML attributes, co-locating state with the element
- Slideshow element is now passed directly through plusSlides → showSlides → updateSlideshowWidth → handleSwipe, eliminating redundant DOM queries
- Replaced hardcoded slideshow ID allowlist in updateSlideshowWidth with a data-dynamic-width attribute
- Replaced string-manipulated reset/overlay IDs with data-frame-id attributes on the relevant elements
- Replaced hardcoded iframe list and zoomMap object with data-zoom-desktop/data-zoom-mobile attributes directly on each iframe
- Minor JS cleanup: fixed implicit globals in date helper functions, modernized pad() to use String.padStart(), inlined getUrlParameter into isDebugEnabled, unified slideshowId type handling, replaced getElementsByClassName with querySelector