### PR TITLE
Add inline links under each radar/satellite map

### DIFF
--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -35,8 +35,9 @@
 		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-		12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
+		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
+		{text-align:left;background-color:#0060bf;box-sizing:border-box;padding:5px 4px}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{
+		height:12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
 		margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;
 		height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:
 		center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;
@@ -46,8 +47,8 @@
 		}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
 		12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
 		width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{
-		background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:
-		10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		background-color:#fff}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;
+		margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
 		.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;
 		display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:
 		5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){
@@ -153,6 +154,22 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
+						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a class="right" id="resetVentusskyFrame" style="display:none">[X]</a>
+					</div>
+					<div class="if1 placeholder">
+						<iframe id="ventussky" class="scaled-iframe" loading="eager" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
+						<div class="overlay" id="overlayVentusskyFrame">
+							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
+						</div>
+					</div>
+				</td>
+			</tr>
+			<tr class="sp"></tr>
+
+			<tr>
+				<td align="center">
+					<div class="radartitle">
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" style="display:none">[X]</a>
 					</div>
@@ -169,27 +186,11 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a class="right" id="resetVentusskyFrame" style="display:none">[X]</a>
-					</div>
-					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="lazy" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
-						<div class="overlay" id="overlayVentusskyFrame">
-							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
-						</div>
-					</div>
-				</td>
-			</tr>
-			<tr class="sp"></tr>
-
-			<tr>
-				<td align="center">
-					<div class="radartitle">
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
 						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="eager" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
 						<div class="overlay" id="overlayWeatherAndRadarFrame">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -468,25 +469,16 @@
 								<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Zagreb</a>
 							</p>
 							<p>
-								<b>Sat24.com</b>
-								<br />Satelit i radar
-								<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Meteoradar</b>
+								<b>Zoom Earth</b>
 								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
+								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>I'm Weather</b>
-								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://zoom.earth/maps/temperature/#view=47.5,17.5,5z/model=icon" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>meteoblue</b>
@@ -507,6 +499,27 @@
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>I'm Weather</b>
+								<br />Satelit i radar
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>Sat24.com</b>
+								<br />Satelit i radar
+								<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>Meteoradar</b>
+								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
+								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Időkép</b>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -36,24 +36,24 @@
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-		10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size
-		:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline
-		:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em}.fade{animation-name:
-		fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:3px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#c7c7c7}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;bottom:0;width:100%;height:2px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
+		margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;
+		height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:
+		center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;
+		width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;
+		text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{
+		right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em
+		}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{
+		background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:
+		10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;
+		display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:
+		5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){
+		.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;
+		color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;bottom:0;width:100%;height:2px;z-index:
+		1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -153,27 +153,11 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather & Radar</a>
-						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
-					</div>
-					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="eager" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
-						<div class="overlay" id="overlayWeatherAndRadarFrame">
-							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
-						</div>
-					</div>
-				</td>
-			</tr>
-			<tr class="sp"></tr>
-
-			<tr>
-				<td align="center">
-					<div class="radartitle">
-						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=1&lm=1&layer=radar&sm=1&sn=2" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=1&lm=1&layer=radar&sm=1&sn=2" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
@@ -185,12 +169,28 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar" target="_blank" rel="nofollow">Ventussky</a>
+						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a class="right" id="resetVentusskyFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="lazy" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="lazy" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame">
+							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
+						</div>
+					</div>
+				</td>
+			</tr>
+			<tr class="sp"></tr>
+
+			<tr>
+				<td align="center">
+					<div class="radartitle">
+						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
+						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
+					</div>
+					<div class="if1 placeholder">
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="eager" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
+						<div class="overlay" id="overlayWeatherAndRadarFrame">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -444,11 +444,11 @@
 							<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
 							<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
 							<br />
-							<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,45.799,15.937,8" target="_blank" rel="nofollow">Windy</a></p>
+							<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
 							<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
 							<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
 							<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
-							<p><a href="https://zoom.earth" target="_blank" rel="nofollow">Zoom Earth</a></p>
+							<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
 							<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
 						</div>
 
@@ -485,16 +485,16 @@
 							<p>
 								<b>I'm Weather</b>
 								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=45.0000&lng=17.0000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>meteoblue</b>
 								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/45/17" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/45/17" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
@@ -502,9 +502,11 @@
 							<p>
 								<b>Weather&Radar</b>
 								<br />Satelit i radar
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44,16&placemark=45.8144,15.978&zoom=5&layer=wr" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44,16&placemark=45.8144,15.978&zoom=5&layer=tr" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Időkép</b>
@@ -517,14 +519,14 @@
 							<p>
 								<b>Blitzortung.org</b>
 								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://map.blitzortung.org/#6.5/45/16" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 								<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>LightningMaps.org</b>
 								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=45;x=17;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
 								<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
 							</p>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -628,7 +628,7 @@
 		</table>
 	</div>
 	<footer>
-		<a onclick="scrollToTop()" style="cursor: pointer"><u>Povratak na vrh</u></a>
+		<a onclick="scrollToTop()" style="cursor: pointer">Povratak na vrh</a>
 		·
 		<a href="/meteo/">Početna</a>
 		|

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -28,36 +28,37 @@
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
 		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto;table-layout:fixed}.placeholder{
 		background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
-		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute
-		;right:0;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{
-		max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px)
-		{.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;
-		pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){
-		.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}
-		.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe
-		,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:
-		calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:
-		calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;
-		padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}
-		.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%
-		;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;
-		align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{
-		position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:
-		absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:
-		.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));
-		color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
-		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
-		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:5px;background-color:#ffffff40;transition:background-color .3s}.indicator.active{background-color:#fff}
-		@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
+		position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
+		text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;
+		padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}
+		.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
+		background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
+		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
+		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
+		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
+		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
+		{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+		-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}
+		@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{
+		margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer
+		;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;
+		justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top
+		:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{
+		left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
+		color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{
+		opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{
+		display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;
+		transition:background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position
+		:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
+		width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
+		2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
+		max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
+		0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
+		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
+		width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -179,7 +180,7 @@
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -213,7 +214,7 @@
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -285,7 +286,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -312,7 +313,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -404,7 +405,7 @@
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
 						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
@@ -665,7 +666,7 @@
 								<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
-								<b>Weather&Radar</b>
+								<b>Vrijeme&Radar</b>
 								<br />Satelit i radar
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -26,30 +26,31 @@
 	<meta name="twitter:image" content="https://maps.neverin.hr/radar/anim_hr.webp">
 	<style>
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
-		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}
-		.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
-		transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
-		none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
-		display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}
-		.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;
-		position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;
-		min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;
-		width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
-		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
-		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
-		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;padding:5px 4px}
-		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5%
-		49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
-		#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{
-		background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:23px}.fade{animation-name:fade;
+		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto;table-layout:fixed}.placeholder{
+		background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
+		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute
+		;right:0;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{
+		max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px)
+		{.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;
+		pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){
+		.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}
+		.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe
+		,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:
+		calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:
+		calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;
+		padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}
+		.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%
+		;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;
+		align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{
+		position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:
+		absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:
+		.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));
+		color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
+		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
 		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#fff}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
+		1px}.indicator{height:5px;background-color:#ffffff40;transition:background-color .3s}.indicator.active{background-color:#fff}
+		@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
 		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
 		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
 		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -369,8 +369,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 804px">
-						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
@@ -380,7 +380,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung | Munje</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
 					</div>
 					<div class="placeholder" style="aspect-ratio: 1;">
 						<img src="https://www.blitzortung.org/Images/image_b_eu.png" />
@@ -390,8 +390,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.rg</a>
 						· <a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
@@ -752,7 +752,7 @@
 						</div>
 
 						<div class="item">
-							<p><b>Kvaliteta zraka</b></p>
+							<p><b><u>Kvaliteta zraka</u></b></p>
 							<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
 							<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
 							<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
@@ -760,14 +760,14 @@
 							<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
 							<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
 							<br />
-							<p><b>SpaceWeather</b></p>
+							<p><b><u>SpaceWeather</u></b></p>
 							<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
 							<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
 							<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
 							<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
 							<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
 							<br />
-							<p><b>Facebook</b></p>
+							<p><b><u>Facebook</u></b></p>
 							<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
 							<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
 							<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -588,7 +588,7 @@
 							<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
 							<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
 							<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
-							<p><a href="https://www.meteoadriatic.net" target=" rel="nofollow">MeteoAdriatic</a></p>
+							<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
 							<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
 							<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
 							<br />
@@ -647,6 +647,24 @@
 								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
 							</p>
 							<p>
+								<b>Ventussky</b>
+								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
+								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
+								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>Rain Viewer</b>
+								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
 								<b>Weather&Radar</b>
 								<br />Satelit i radar
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
@@ -658,8 +676,8 @@
 							<p>
 								<b>I'm Weather</b>
 								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Sat24.com</b>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -27,7 +27,7 @@
 	<style>
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
 		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}
-		.radartitle{position:relative;max-width:100%;background-color:#1a55af;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
+		.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
 		transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
 		none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
 		display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}
@@ -37,7 +37,7 @@
 		width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
 		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
 		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
-		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#9b1f1f;box-sizing:border-box;padding:5px 4px}
+		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;padding:5px 4px}
 		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5%
 		49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
 		#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -54,8 +54,8 @@
 		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:4px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
 		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
 		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
 		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -171,6 +171,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -191,6 +205,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -208,6 +236,20 @@
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -234,6 +276,21 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 821px">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -243,6 +300,20 @@
 					</div>
 					<div class="placeholder" style="max-width: 840px; aspect-ratio: 840 / 600;">
 						<img src="https://www.idokep.eu/terkep/eu/radar.gif" />
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 840px">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -258,6 +329,19 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -270,15 +354,33 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 804px">
+						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung | Munje</a>
 					</div>
 					<div class="placeholder" style="aspect-ratio: 1;">
 						<img src="https://www.blitzortung.org/Images/image_b_eu.png" />
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -294,6 +396,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -303,6 +419,13 @@
 					</div>
 					<div class="placeholder" style="max-width: 720px; aspect-ratio: 1;">
 						<img src="https://prognoza.hr/web_fronte_sutra12.jpg" />
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 720px">
+						<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ</a>
 					</div>
 				</td>
 			</tr>
@@ -444,7 +567,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp20"></tr>
+			<tr class="sp"></tr>
 
 			<tr>
 				<td align="center" id="links">

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -39,23 +39,28 @@
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
 		{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
-		-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}
-		@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{
-		margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer
-		;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;
-		justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top
-		:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{
-		left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
-		color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{
-		opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{
-		display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;
-		transition:background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position
-		:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
-		width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
-		2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
-		max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
-		0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
+		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+		margin-right:-24px;background:linear-gradient(to left,transparent,#6e2424)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#6e2424)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;transition:
+		background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
+		justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
+		height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
+		font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height
+		 .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;
+		text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
 		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
 		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
 		width .3s ease-in-out}
@@ -84,12 +89,16 @@
 		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
 		o=e.touches[0].clientY),i=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?i=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o
-		;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o
+		;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}let previousWidth=0;function updateIframeSrc(){
+		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
+		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
+		document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
+		updateLinksScrollShadows()}let previousWidth=0;function updateIframeSrc(){
 		window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
@@ -105,7 +114,7 @@
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
 		;const n=e.querySelector(".hint");let r=0,i=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(i=e.touches[0].clientX,
 		r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,a=Math.abs(t-i),s=Math.abs(o-r);a<10&&s<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,s=Math.abs(t-i),a=Math.abs(o-r);s<10&&a<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -126,8 +135,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),
-		window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),addLinksScrollShadows()}),window.addEventListener("resize",()=>{
+		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText(),updateLinksScrollShadows()
+		},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -187,13 +187,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -221,13 +221,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -255,13 +255,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -292,14 +292,14 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 821px">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -319,13 +319,13 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 840px">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -345,12 +345,12 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -370,8 +370,8 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 804px">
 						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
-						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -391,8 +391,8 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
-						<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						· <a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -412,13 +412,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
-						<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						· <a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
+						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
 				</td>
 			</tr>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -38,12 +38,12 @@
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-		{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+		{text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
 		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
 		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
 		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#6e2424)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#6e2424)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
 		1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
 		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
 		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
@@ -54,7 +54,7 @@
 		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;transition:
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#4e5264;transition:
 		background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
 		justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
 		height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -401,10 +401,10 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
+						<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
 					</div>
 					<div class="placeholder" style="aspect-ratio: 959 / 741;">
-						<img src="https://www.wetterzentrale.de/en/create_gif.php?model=ICO&member=OP&var=5&map=IT&run=06&speed=250&times=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47" alt="Wetterzentrale Temperatura" />
+						<img src="https://www.wetterzentrale.de/en/create_gif.php?model=ECM&member=OP&var=5&map=IT&run=06&speed=250&times=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47" alt="Wetterzentrale Temperatura" />
 					</div>
 				</td>
 			</tr>
@@ -732,10 +732,10 @@
 								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 								<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
 								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
+								<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ico&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Meteociel.fr</b>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -237,7 +237,7 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
-						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
+						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -38,32 +38,33 @@
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-		{text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+		{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
 		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
 		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
 		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
 		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
 		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}.slideshow{position:
+		relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
+		align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
+		user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
+		text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
+		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
+		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
+		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{
+		height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}@media (max-width:800px){
+		.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff
+		;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}
+		.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;
+		gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){
+		border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{
+		margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;
+		margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{
+		width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -72,12 +73,16 @@
 		;const t=document.querySelector(".links");t.style.maxHeight?(t.style.maxHeight=null,
 		e.textContent="▼"):(t.style.maxHeight=t.scrollHeight+"px",e.textContent="▲",setTimeout(()=>{
 		document.documentElement.style.scrollBehavior="auto",document.body.style.scrollBehavior="auto",scrollToElement("links"),setTimeout(()=>{
-		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}function plusSlides(e,t){
+		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}
+		function toggleLinksBottom(e){document.body.classList.toggle("show-links-bottom",e.checked),
+		localStorage.setItem("showLinksBottom",e.checked?"1":"0"),updateLinksScrollShadows()}function initLinksBottom(){
+		const e=document.querySelector(".links-toggle");e&&(e.checked="1"===localStorage.getItem("showLinksBottom"),
+		document.body.classList.toggle("show-links-bottom",e.checked))}function plusSlides(e,t){
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
 		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
-		n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
+		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -86,15 +91,15 @@
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
-		o=e.touches[0].clientY),i=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?i=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o
-		;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		o=e.touches[0].clientY),s=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?s=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
+		Math.abs(n-t)>Math.abs(r-o)&&(s=!0))}),e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o
+		;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
+		e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
+		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
@@ -110,11 +115,11 @@
 		;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
 		let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
 		setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),i=r-t;if(i>0&&i<200){e.style.display="none"
+		if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),s=r-t;if(s>0&&s<200){e.style.display="none"
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
-		;const n=e.querySelector(".hint");let r=0,i=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(i=e.touches[0].clientX,
+		;const n=e.querySelector(".hint");let r=0,s=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(s=e.touches[0].clientX,
 		r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,s=Math.abs(t-i),a=Math.abs(o-r);s<10&&a<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-s),a=Math.abs(o-r);i<10&&a<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -135,9 +140,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),addLinksScrollShadows()}),window.addEventListener("resize",()=>{
-		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText(),updateLinksScrollShadows()
-		},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
+		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>
@@ -159,7 +164,10 @@
 				<td align="center">
 					<div class="buttons">
 						<a href="/meteo/" style="text-decoration: none"><div class="btn">Početna</div></a>
-						<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+						<div class="links-btn">
+							<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+							<input type="checkbox" class="links-toggle" onchange="toggleLinksBottom(this)" title="Prikaži linkove ispod karata" />
+						</div>
 					</div>
 				</td>
 			</tr>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -48,23 +48,24 @@
 		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
 		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
 		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}.slideshow{position:
-		relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
-		align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
-		user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
-		text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
-		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
-		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{
-		height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}@media (max-width:800px){
-		.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff
-		;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}
-		.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;
-		gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){
-		border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{
-		margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;
-		margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{
-		width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -145,6 +145,7 @@
 		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
 		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
+	
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>
 		window.dataLayer = window.dataLayer || [];
@@ -177,16 +178,16 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventussky', this)">[HR]</a>
-						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventusky', this)">[HR]</a>
+						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
+						<a class="right" id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" frameborder="0"
+						<iframe id="ventusky" class="scaled-iframe" loading="eager" frameborder="0"
 								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-hr-desktop=";6&" data-zoom-hr-mobile=";6&"
 								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off" data-zoom-eu-desktop=";4&" data-zoom-eu-mobile=";3&">
 						</iframe>
-						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
+						<div class="overlay" id="overlayVentuskyFrame" data-frame-id="ventusky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -232,7 +233,7 @@
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -267,7 +268,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -304,7 +305,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -331,7 +332,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
@@ -356,7 +357,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
@@ -364,6 +365,8 @@
 				</td>
 			</tr>
 			<tr class="sp20"></tr>
+
+			
 
 			<tr>
 				<td align="center">
@@ -400,7 +403,7 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.rg</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						· <a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
@@ -423,7 +426,7 @@
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						· <a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
@@ -600,190 +603,190 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<div class="links">
-						<div class="item">
-							<p><a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a></p>
-							<p><a href="https://vrijeme-i-promet.hrt.hr/vrijeme" target="_blank" rel="nofollow">HRT Vrijeme</a></p>
-							<p><a href="https://www.neverin.hr/prognoza/" target="_blank" rel="nofollow">Neverin</a></p>
-							<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
-							<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
-							<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
-							<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
-							<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
-							<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
-							<br />
-							<p><a href="https://view.eumetsat.int/productviewer?v=default" target="_blank" rel="nofollow">EUMETView</a></p>
-							<p><a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a></p>
-							<p><a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a></p>
-							<p><a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a></p>
-							<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
-							<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
-							<br />
-							<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
-							<p><a href="https://www.rain-alarm.com" target="_blank" rel="nofollow">Rain Alarm</a></p>
-							<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
-							<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
-							<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
-							<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
-							<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
-						</div>
+					<div class="links">						
+<div class="item">
+	<p><a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a></p>
+	<p><a href="https://vrijeme-i-promet.hrt.hr/vrijeme" target="_blank" rel="nofollow">HRT Vrijeme</a></p>
+	<p><a href="https://www.neverin.hr/prognoza/" target="_blank" rel="nofollow">Neverin</a></p>
+	<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
+	<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
+	<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
+	<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
+	<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
+	<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
+	<br />
+	<p><a href="https://view.eumetsat.int/productviewer?v=default" target="_blank" rel="nofollow">EUMETView</a></p>
+	<p><a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a></p>
+	<p><a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a></p>
+	<p><a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a></p>
+	<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
+	<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
+	<br />
+	<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
+	<p><a href="https://www.rain-alarm.com" target="_blank" rel="nofollow">Rain Alarm</a></p>
+	<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
+	<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
+	<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
+	<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
+	<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
+</div>
 
-						<div class="item">
-							<p>
-								<b>Neverin</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.neverin.hr/radar/#:~:text=Meteo%20radar%20Europa" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.neverin.hr/satelit/#:~:text=Satelitska%20snimka%20Europe" target="_blank" rel="nofollow">Europa</a>
-								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Europa</a>
-								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Zagreb</a>
-							</p>
-							<p>
-								<b>Zoom Earth</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://zoom.earth/maps/temperature/#view=47.5,17.5,5z/model=icon" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>meteoblue</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
-								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
-							</p>
-							<p>
-								<b>Ventussky</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Rain Viewer</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Vrijeme&Radar</b>
-								<br />Satelit i radar
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>I'm Weather</b>
-								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Sat24.com</b>
-								<br />Satelit i radar
-								<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Meteoradar</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Időkép</b>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.idokep.hu/muhold#europa" target="_blank" rel="nofollow">Europa</a>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Blitzortung.org</b>
-								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
-								<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>LightningMaps.org</b>
-								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
-								<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Wetterzentrale</b>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
-								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Meteociel.fr</b>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=eur2" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>WXCharts</b>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=italy&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=europe&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Europa</a>
-							</p>
-						</div>
+<div class="item">
+	<p>
+		<b>Neverin</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.neverin.hr/radar/#:~:text=Meteo%20radar%20Europa" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.neverin.hr/satelit/#:~:text=Satelitska%20snimka%20Europe" target="_blank" rel="nofollow">Europa</a>
+		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Europa</a>
+		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Zagreb</a>
+	</p>
+	<p>
+		<b>Zoom Earth</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://zoom.earth/maps/temperature/#view=47.5,17.5,5z/model=icon" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>meteoblue</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
+		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
+	</p>
+	<p>
+		<b>Ventusky</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Rain Viewer</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Vrijeme&Radar</b>
+		<br />Satelit i radar
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>I'm Weather</b>
+		<br />Satelit i radar
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Sat24.com</b>
+		<br />Satelit i radar
+		<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Meteoradar</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Időkép</b>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.idokep.hu/muhold#europa" target="_blank" rel="nofollow">Europa</a>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Blitzortung.org</b>
+		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>LightningMaps.org</b>
+		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Wetterzentrale</b>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
+		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Meteociel.fr</b>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=eur2" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>WXCharts</b>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=italy&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=europe&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Europa</a>
+	</p>
+</div>
 
-						<div class="item">
-							<p><b><u>Kvaliteta zraka</u></b></p>
-							<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
-							<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
-							<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
-							<p><a href="https://www.meteoblue.com/en/weather/outdoorsports/airquality/zagreb_croatia_3186886" target="_blank" rel="nofollow">Meteoblue</a></p>
-							<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
-							<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
-							<br />
-							<p><b><u>SpaceWeather</u></b></p>
-							<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
-							<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
-							<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
-							<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
-							<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
-							<br />
-							<p><b><u>Facebook</u></b></p>
-							<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
-							<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
-							<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>
-							<p><a href="https://www.facebook.com/vrijeme.net" target="_blank" rel="nofollow">Vrijeme.net</a></p>
-							<p><a href="https://www.facebook.com/severeweatherEU" target="_blank" rel="nofollow">Severe Weather Europe</a></p>
-							<p><a href="https://www.facebook.com/StormchasersSlovenija" target="_blank" rel="nofollow">Neurje.si</a></p>
-						</div>
+<div class="item">
+	<p><b><u>Kvaliteta zraka</u></b></p>
+	<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
+	<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
+	<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
+	<p><a href="https://www.meteoblue.com/en/weather/outdoorsports/airquality/zagreb_croatia_3186886" target="_blank" rel="nofollow">Meteoblue</a></p>
+	<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
+	<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
+	<br />
+	<p><b><u>SpaceWeather</u></b></p>
+	<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
+	<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
+	<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
+	<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
+	<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
+	<br />
+	<p><b><u>Facebook</u></b></p>
+	<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
+	<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
+	<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>
+	<p><a href="https://www.facebook.com/vrijeme.net" target="_blank" rel="nofollow">Vrijeme.net</a></p>
+	<p><a href="https://www.facebook.com/severeweatherEU" target="_blank" rel="nofollow">Severe Weather Europe</a></p>
+	<p><a href="https://www.facebook.com/StormchasersSlovenija" target="_blank" rel="nofollow">Neurje.si</a></p>
+</div>
 					</div>
 				</td>
 			</tr>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -38,7 +38,7 @@
 		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
 		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
 		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#9b1f1f;box-sizing:border-box;padding:5px 4px}
-		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5%
+		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5%
 		49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
 		#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}
 		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
@@ -171,7 +171,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -191,7 +191,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -211,7 +211,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -234,7 +234,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -246,7 +246,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -258,7 +258,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -270,7 +270,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -282,7 +282,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -294,7 +294,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -306,7 +306,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -329,7 +329,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -352,7 +352,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -375,7 +375,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -398,7 +398,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -421,7 +421,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -444,7 +444,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center" id="links">

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -215,7 +215,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.arso.gov.si/met/sl/weather/observ/radar/" target="_blank" rel="nofollow">meteo.si</a>
+					<div class="radartitle" style="max-width: 821px;">
+						<a href="https://meteo.arso.gov.si/met/sl/weather/observ/radar/" target="_blank" rel="nofollow">meteo.si</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="6" data-current-slide="1" style="max-width: 821px; aspect-ratio: 821 / 660; ">
 						<div class="slide fade active">
 							<img src="https://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm-anim.gif?nocache" />
@@ -236,7 +238,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Időkép | Radar | Europa</a>
+					<div class="radartitle" style="max-width: 840px;">
+						<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Időkép | Radar | Europa</a>
+					</div>
 					<div class="placeholder" style="max-width: 840px; aspect-ratio: 840 / 600;">
 						<img src="https://www.idokep.eu/terkep/eu/radar.gif" />
 					</div>
@@ -246,7 +250,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.idokep.hu/muhold" target="_blank" rel="nofollow">Időkép | Satelit | Europa</a>
+					<div class="radartitle">
+						<a href="https://www.idokep.hu/muhold" target="_blank" rel="nofollow">Időkép | Satelit | Europa</a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 1070 / 713;">
 						<div class="vid1"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/radar/sat-eu.mp4"></video></div>
 					</div>
@@ -256,7 +262,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.istramet.hr/radari-munja/" target="_blank" rel="nofollow">Istramet | Munje</a>
+					<div class="radartitle" style="max-width: 804px;">
+						<a href="https://www.istramet.hr/radari-munja/" target="_blank" rel="nofollow">Istramet | Munje</a>
+					</div>
 					<div class="placeholder" style="max-width: 804px; aspect-ratio: 804 / 687; ">
 						<img src="https://www.istramet.hr/wp-content/themes/istramet/img/munje_hr.png" />
 					</div>
@@ -266,7 +274,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+					<div class="radartitle">
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 1;">
 						<img src="https://www.blitzortung.org/Images/image_b_eu.png" />
 					</div>
@@ -276,7 +286,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
+					<div class="radartitle">
+						<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 959 / 741;">
 						<img src="https://www.wetterzentrale.de/en/create_gif.php?model=ICO&member=OP&var=5&map=IT&run=06&speed=250&times=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47" alt="Wetterzentrale Temperatura" />
 					</div>
@@ -286,7 +298,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ | Sinoptička karta</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ | Sinoptička karta</a>
+					</div>
 					<div class="placeholder" style="max-width: 720px; aspect-ratio: 1;">
 						<img src="https://prognoza.hr/web_fronte_sutra12.jpg" />
 					</div>
@@ -296,7 +310,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=puntijarka&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Puntijarka</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=puntijarka&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Puntijarka</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="8" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_puntijarka.gif" />
@@ -317,7 +333,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=bilogora&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Bilogora</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=bilogora&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Bilogora</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="9" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_bilogora.gif" />
@@ -338,7 +356,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=gradiste&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Gradište</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=gradiste&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Gradište</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="10" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_gradiste.gif" />
@@ -359,7 +379,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=goli&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Goli</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=goli&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Goli</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="11" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_goli.gif" />
@@ -380,7 +402,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=debeljak&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Debeljak</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=debeljak&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Debeljak</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="12" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_debeljak.gif" />
@@ -401,7 +425,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=uljenje&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Uljenje</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=uljenje&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Uljenje</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="13" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_uljenje.gif" />

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -54,16 +54,16 @@
 		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#4e5264;transition:
-		background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
-		justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
-		height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
-		font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height
-		 .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;
-		text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
-		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
-		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
-		width .3s ease-in-out}
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:4px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,24 +36,24 @@
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-		10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size
-		:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline
-		:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em}.fade{animation-name:
-		fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:3px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#c7c7c7}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;bottom:0;width:100%;height:2px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
+		margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;
+		height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:
+		center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;
+		width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;
+		text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{
+		right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em
+		}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{
+		background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:
+		10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;
+		display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:
+		5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){
+		.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;
+		color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;bottom:0;width:100%;height:2px;z-index:
+		1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -173,7 +173,20 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="left">
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -198,7 +211,16 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="left">
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+					<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -223,7 +245,18 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="left">
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+					<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -248,12 +281,21 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="left">
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+					<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,8" target="_blank" rel="nofollow">Windy</a>
+						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a class="right" id="resetWindyFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
@@ -311,12 +353,24 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="center">
+					<div style="max-width: 768px; text-align:left">
+						<br /><b>></b>
+						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					</div>
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
+						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						<a class="right" id="resetBlitzortungFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
@@ -460,11 +514,11 @@
 							<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
 							<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
 							<br />
-							<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,45.799,15.937,8" target="_blank" rel="nofollow">Windy</a></p>
+							<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
 							<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
 							<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
 							<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
-							<p><a href="https://zoom.earth" target="_blank" rel="nofollow">Zoom Earth</a></p>
+							<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
 							<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
 						</div>
 
@@ -501,16 +555,16 @@
 							<p>
 								<b>I'm Weather</b>
 								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=45.0000&lng=17.0000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>meteoblue</b>
 								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/45/17" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/45/17" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
@@ -518,9 +572,11 @@
 							<p>
 								<b>Weather&Radar</b>
 								<br />Satelit i radar
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44,16&placemark=45.8144,15.978&zoom=5&layer=wr" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44,16&placemark=45.8144,15.978&zoom=5&layer=tr" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Időkép</b>
@@ -533,14 +589,14 @@
 							<p>
 								<b>Blitzortung.org</b>
 								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://map.blitzortung.org/#6.5/45/16" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 								<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>LightningMaps.org</b>
 								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=45;x=17;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
 								<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
 							</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,8 +35,9 @@
 		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-		12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
+		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
+		{text-align:left;background-color:#0060bf;box-sizing:border-box;padding:5px 4px}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{
+		height:12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
 		margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;
 		height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:
 		center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;
@@ -46,8 +47,8 @@
 		}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
 		12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
 		width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{
-		background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:
-		10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		background-color:#fff}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;
+		margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
 		.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;
 		display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:
 		5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){
@@ -175,15 +176,14 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>></b>
-					<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -213,11 +213,12 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>></b>
-					<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -247,13 +248,14 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>></b>
-					<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -283,11 +285,12 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>></b>
-					<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -355,8 +358,7 @@
 			</tr>
 			<tr>
 				<td align="center">
-					<div style="max-width: 768px; text-align:left">
-						<br /><b>></b>
+					<div class="links-bottom" style="max-width: 768px">
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -538,25 +540,16 @@
 								<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Zagreb</a>
 							</p>
 							<p>
-								<b>Sat24.com</b>
-								<br />Satelit i radar
-								<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Meteoradar</b>
+								<b>Zoom Earth</b>
 								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
+								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>I'm Weather</b>
-								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://zoom.earth/maps/temperature/#view=47.5,17.5,5z/model=icon" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>meteoblue</b>
@@ -577,6 +570,27 @@
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>I'm Weather</b>
+								<br />Satelit i radar
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>Sat24.com</b>
+								<br />Satelit i radar
+								<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>Meteoradar</b>
+								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
+								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Időkép</b>

--- a/docs/index.html
+++ b/docs/index.html
@@ -729,7 +729,7 @@
 						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 						· <a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
 						· <a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
-						· <a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -885,10 +885,10 @@
 								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 								<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
 								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
+								<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
 								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ico&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Meteociel.fr</b>

--- a/docs/index.html
+++ b/docs/index.html
@@ -793,7 +793,7 @@
 		<img src="https://bit.ly/radari-counter" style="width:1px;height:1px;float:right" />
 	</div>
 	<footer>
-		<a onclick="scrollToTop()" style="cursor: pointer"><u>Povratak na vrh</u></a>
+		<a onclick="scrollToTop()" style="cursor: pointer">Povratak na vrh</a>
 		·
 		<a href="/meteo/extras/">Više</a>
 		|

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
 		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
 		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#9b1f1f;box-sizing:border-box;padding:5px 4px}
-		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5%
+		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5%
 		49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
 		#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}
 		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
@@ -190,7 +190,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -227,7 +227,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -266,7 +266,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -303,7 +303,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -323,7 +323,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -346,7 +346,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -387,7 +387,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -407,7 +407,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -434,7 +434,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -457,7 +457,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -469,7 +469,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -501,7 +501,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -549,7 +549,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -561,7 +561,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,30 +26,31 @@
 	<meta name="twitter:image" content="https://maps.neverin.hr/radar/anim_hr.webp">
 	<style>
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
-		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}
-		.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
-		transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
-		none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
-		display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}
-		.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;
-		position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;
-		min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;
-		width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
-		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
-		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
-		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;padding:5px 4px}
-		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5%
-		49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
-		#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{
-		background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:23px}.fade{animation-name:fade;
+		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto;table-layout:fixed}.placeholder{
+		background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
+		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute
+		;right:0;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{
+		max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px)
+		{.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;
+		pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){
+		.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}
+		.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe
+		,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:
+		calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:
+		calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;
+		padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}
+		.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%
+		;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;
+		align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{
+		position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:
+		absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:
+		.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));
+		color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
+		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
 		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#fff}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
+		1px}.indicator{height:5px;background-color:#ffffff40;transition:background-color .3s}.indicator.active{background-color:#fff}
+		@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
 		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
 		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
 		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0

--- a/docs/index.html
+++ b/docs/index.html
@@ -187,9 +187,9 @@
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép*</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -227,8 +227,8 @@
 						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -268,8 +268,8 @@
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -307,9 +307,9 @@
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -336,12 +336,14 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth*</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue*</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky*</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R*</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -371,8 +373,15 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 720px">
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
-						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy*</a>
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -414,8 +423,8 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar*</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak*</a>
+						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
 				</td>
 			</tr>
@@ -442,8 +451,9 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps*</a>
-						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin*</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung</a>
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -477,8 +487,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 900px">
-						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX*</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>
@@ -508,8 +518,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 800px">
-						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL*</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>
@@ -534,8 +544,8 @@
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -578,9 +588,9 @@
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -635,7 +645,7 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 760px">
-						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ*</a>
+						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ</a>
 					</div>
 				</td>
 			</tr>
@@ -702,10 +712,12 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ*</a>
-						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin*</a>
-						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no*</a>
-						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale*</a>
+						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a>
+						<a href="https://vrijeme-i-promet.hrt.hr/vrijeme/" target="_blank" rel="nofollow">HRT Vrijeme</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
+						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
+						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,32 +38,33 @@
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-		{text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+		{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
 		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
 		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
 		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
 		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
 		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}.slideshow{position:
+		relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
+		align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
+		user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
+		text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
+		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
+		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
+		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{
+		height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}@media (max-width:800px){
+		.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff
+		;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}
+		.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;
+		gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){
+		border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{
+		margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;
+		margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{
+		width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -72,12 +73,16 @@
 		;const t=document.querySelector(".links");t.style.maxHeight?(t.style.maxHeight=null,
 		e.textContent="▼"):(t.style.maxHeight=t.scrollHeight+"px",e.textContent="▲",setTimeout(()=>{
 		document.documentElement.style.scrollBehavior="auto",document.body.style.scrollBehavior="auto",scrollToElement("links"),setTimeout(()=>{
-		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}function plusSlides(e,t){
+		document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}
+		function toggleLinksBottom(e){document.body.classList.toggle("show-links-bottom",e.checked),
+		localStorage.setItem("showLinksBottom",e.checked?"1":"0"),updateLinksScrollShadows()}function initLinksBottom(){
+		const e=document.querySelector(".links-toggle");e&&(e.checked="1"===localStorage.getItem("showLinksBottom"),
+		document.body.classList.toggle("show-links-bottom",e.checked))}function plusSlides(e,t){
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
 		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
-		n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
+		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -86,15 +91,15 @@
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
-		o=e.touches[0].clientY),i=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?i=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o
-		;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		o=e.touches[0].clientY),s=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?s=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
+		Math.abs(n-t)>Math.abs(r-o)&&(s=!0))}),e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o
+		;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
+		e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
+		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
@@ -110,11 +115,11 @@
 		;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
 		let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
 		setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),i=r-t;if(i>0&&i<200){e.style.display="none"
+		if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),s=r-t;if(s>0&&s<200){e.style.display="none"
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
-		;const n=e.querySelector(".hint");let r=0,i=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(i=e.touches[0].clientX,
+		;const n=e.querySelector(".hint");let r=0,s=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(s=e.touches[0].clientX,
 		r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,s=Math.abs(t-i),a=Math.abs(o-r);s<10&&a<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-s),a=Math.abs(o-r);i<10&&a<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -135,9 +140,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),addLinksScrollShadows()}),window.addEventListener("resize",()=>{
-		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText(),updateLinksScrollShadows()
-		},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
+		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>
@@ -159,7 +164,10 @@
 				<td align="center">
 					<div class="buttons">
 						<a href="/meteo/extras/" style="text-decoration: none"><div class="btn">Više</div></a>
-						<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+						<div class="links-btn">
+							<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+							<input type="checkbox" class="links-toggle" onchange="toggleLinksBottom(this)" title="Prikaži linkove ispod karata" />
+						</div>
 					</div>
 				</td>
 			</tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
 	<style>
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
 		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}
-		.radartitle{position:relative;max-width:100%;background-color:#1a55af;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
+		.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
 		transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
 		none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
 		display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}
@@ -37,7 +37,7 @@
 		width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
 		;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
 		calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
-		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#9b1f1f;box-sizing:border-box;padding:5px 4px}
+		calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;padding:5px 4px}
 		@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5%
 		49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
 		#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}

--- a/docs/index.html
+++ b/docs/index.html
@@ -145,6 +145,7 @@
 		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
 		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
+	
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>
 		window.dataLayer = window.dataLayer || [];
@@ -206,7 +207,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -247,7 +248,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -287,7 +288,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
@@ -327,7 +328,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
@@ -360,7 +361,7 @@
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -398,7 +399,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -442,7 +443,7 @@
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
@@ -563,7 +564,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
@@ -591,14 +592,14 @@
 								<img data-src="https://modeles20.meteociel.fr/satellite/latestsatirmtgeu.png" class="lazy" />
 							</div>
 						</div>
-
+						
 						<a class="prev shorter" onclick="plusSlides(5, -1)">&#10094;</a>
 						<a class="next shorter" onclick="plusSlides(5, 1)">&#10095;</a>
 					</div>
 					<div class="indicators-container" data-slideshow-id="5" style="max-width: 768px; grid-template-columns: repeat(2, 1fr);">
 						<span class="indicator active"></span>
 						<span class="indicator"></span>
-
+						
 					</div>
 				</td>
 			</tr>
@@ -608,7 +609,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
@@ -753,190 +754,190 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<div class="links">
-						<div class="item">
-							<p><a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a></p>
-							<p><a href="https://vrijeme-i-promet.hrt.hr/vrijeme" target="_blank" rel="nofollow">HRT Vrijeme</a></p>
-							<p><a href="https://www.neverin.hr/prognoza/" target="_blank" rel="nofollow">Neverin</a></p>
-							<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
-							<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
-							<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
-							<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
-							<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
-							<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
-							<br />
-							<p><a href="https://view.eumetsat.int/productviewer?v=default" target="_blank" rel="nofollow">EUMETView</a></p>
-							<p><a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a></p>
-							<p><a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a></p>
-							<p><a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a></p>
-							<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
-							<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
-							<br />
-							<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
-							<p><a href="https://www.rain-alarm.com" target="_blank" rel="nofollow">Rain Alarm</a></p>
-							<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
-							<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
-							<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
-							<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
-							<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
-						</div>
+					<div class="links">						
+<div class="item">
+	<p><a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a></p>
+	<p><a href="https://vrijeme-i-promet.hrt.hr/vrijeme" target="_blank" rel="nofollow">HRT Vrijeme</a></p>
+	<p><a href="https://www.neverin.hr/prognoza/" target="_blank" rel="nofollow">Neverin</a></p>
+	<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
+	<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
+	<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
+	<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
+	<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
+	<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
+	<br />
+	<p><a href="https://view.eumetsat.int/productviewer?v=default" target="_blank" rel="nofollow">EUMETView</a></p>
+	<p><a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a></p>
+	<p><a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a></p>
+	<p><a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a></p>
+	<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
+	<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
+	<br />
+	<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
+	<p><a href="https://www.rain-alarm.com" target="_blank" rel="nofollow">Rain Alarm</a></p>
+	<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
+	<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
+	<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
+	<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
+	<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
+</div>
 
-						<div class="item">
-							<p>
-								<b>Neverin</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.neverin.hr/radar/#:~:text=Meteo%20radar%20Europa" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.neverin.hr/satelit/#:~:text=Satelitska%20snimka%20Europe" target="_blank" rel="nofollow">Europa</a>
-								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Europa</a>
-								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Zagreb</a>
-							</p>
-							<p>
-								<b>Zoom Earth</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://zoom.earth/maps/temperature/#view=47.5,17.5,5z/model=icon" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>meteoblue</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
-								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
-							</p>
-							<p>
-								<b>Ventussky</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Rain Viewer</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Vrijeme&Radar</b>
-								<br />Satelit i radar
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>I'm Weather</b>
-								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Sat24.com</b>
-								<br />Satelit i radar
-								<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Meteoradar</b>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Időkép</b>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.idokep.hu/muhold#europa" target="_blank" rel="nofollow">Europa</a>
-								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Blitzortung.org</b>
-								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
-								<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>LightningMaps.org</b>
-								<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
-								<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Wetterzentrale</b>
-								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
-								<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>Meteociel.fr</b>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=eur2" target="_blank" rel="nofollow">Europa</a>
-							</p>
-							<p>
-								<b>WXCharts</b>
-								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-								<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=italy&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=europe&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Europa</a>
-							</p>
-						</div>
+<div class="item">
+	<p>
+		<b>Neverin</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.neverin.hr/radar/#:~:text=Meteo%20radar%20Europa" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.neverin.hr/satelit/#:~:text=Satelitska%20snimka%20Europe" target="_blank" rel="nofollow">Europa</a>
+		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Europa</a>
+		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Zagreb</a>
+	</p>
+	<p>
+		<b>Zoom Earth</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://zoom.earth/maps/temperature/#view=47.5,17.5,5z/model=icon" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>meteoblue</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
+		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
+	</p>
+	<p>
+		<b>Ventusky</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Rain Viewer</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Vrijeme&Radar</b>
+		<br />Satelit i radar
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>I'm Weather</b>
+		<br />Satelit i radar
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Sat24.com</b>
+		<br />Satelit i radar
+		<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Meteoradar</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoradar.co.uk/en-gb/continent/eu" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoradar.co.uk/en-gb/continent/eu/maps/temperature" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Időkép</b>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.idokep.hu/muhold#europa" target="_blank" rel="nofollow">Europa</a>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Blitzortung.org</b>
+		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>LightningMaps.org</b>
+		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Wetterzentrale</b>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
+		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Meteociel.fr</b>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=eur2" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>WXCharts</b>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=italy&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.wxcharts.com/?panel=default&model=icon_eu,icon_eu,icon_eu,icon_eu&region=europe&chart=2mtemp,overview,wind10mkph,snowdepth&run=06&step=000&plottype=10&lat=45.813&lon=15.977&skewtstep=0" target="_blank" rel="nofollow">Europa</a>
+	</p>
+</div>
 
-						<div class="item">
-							<p><b><u>Kvaliteta zraka</u></b></p>
-							<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
-							<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
-							<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
-							<p><a href="https://www.meteoblue.com/en/weather/outdoorsports/airquality/zagreb_croatia_3186886" target="_blank" rel="nofollow">Meteoblue</a></p>
-							<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
-							<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
-							<br />
-							<p><b><u>SpaceWeather</u></b></p>
-							<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
-							<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
-							<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
-							<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
-							<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
-							<br />
-							<p><b><u>Facebook</u></b></p>
-							<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
-							<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
-							<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>
-							<p><a href="https://www.facebook.com/vrijeme.net" target="_blank" rel="nofollow">Vrijeme.net</a></p>
-							<p><a href="https://www.facebook.com/severeweatherEU" target="_blank" rel="nofollow">Severe Weather Europe</a></p>
-							<p><a href="https://www.facebook.com/StormchasersSlovenija" target="_blank" rel="nofollow">Neurje.si</a></p>
-						</div>
+<div class="item">
+	<p><b><u>Kvaliteta zraka</u></b></p>
+	<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
+	<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
+	<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
+	<p><a href="https://www.meteoblue.com/en/weather/outdoorsports/airquality/zagreb_croatia_3186886" target="_blank" rel="nofollow">Meteoblue</a></p>
+	<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
+	<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
+	<br />
+	<p><b><u>SpaceWeather</u></b></p>
+	<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
+	<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
+	<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
+	<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
+	<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
+	<br />
+	<p><b><u>Facebook</u></b></p>
+	<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
+	<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
+	<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>
+	<p><a href="https://www.facebook.com/vrijeme.net" target="_blank" rel="nofollow">Vrijeme.net</a></p>
+	<p><a href="https://www.facebook.com/severeweatherEU" target="_blank" rel="nofollow">Severe Weather Europe</a></p>
+	<p><a href="https://www.facebook.com/StormchasersSlovenija" target="_blank" rel="nofollow">Neurje.si</a></p>
+</div>
 					</div>
 				</td>
 			</tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,12 +38,12 @@
 		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-		{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+		{text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
 		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
 		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
 		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#6e2424)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#6e2424)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
 		1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
 		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
 		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
@@ -54,7 +54,7 @@
 		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;transition:
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#4e5264;transition:
 		background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
 		justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
 		height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
@@ -531,7 +531,7 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 800px">
 						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
+						· <a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,8 +54,8 @@
 		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:4px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
 		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
 		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
 		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}

--- a/docs/index.html
+++ b/docs/index.html
@@ -179,7 +179,7 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
@@ -187,6 +187,9 @@
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép*</a>
 					</div>
 				</td>
 			</tr>
@@ -218,12 +221,14 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
 					</div>
 				</td>
 			</tr>
@@ -255,14 +260,16 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
 					</div>
 				</td>
 			</tr>
@@ -294,12 +301,15 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
 					</div>
 				</td>
 			</tr>
@@ -323,12 +333,24 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth*</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue*</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky*</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R*</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
 					<div class="radartitle" style="max-width: 720px;">
-						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | kompozit</a>
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | Radar | Hrvatska</a>
 					</div>
 					<div class="slideshow placeholder" data-slideshow-id="7" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
@@ -343,6 +365,14 @@
 					<div class="indicators-container" data-slideshow-id="7" style="max-width: 720px; grid-template-columns: repeat(2, 1fr);">
 						<span class="indicator active"></span>
 						<span class="indicator"></span>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 720px">
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy*</a>
 					</div>
 				</td>
 			</tr>
@@ -384,6 +414,8 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar*</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak*</a>
 					</div>
 				</td>
 			</tr>
@@ -393,7 +425,7 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
-						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
+						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung | Munje</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
@@ -404,6 +436,14 @@
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps*</a>
+						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin*</a>
 					</div>
 				</td>
 			</tr>
@@ -434,6 +474,14 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 900px">
+						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX*</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -457,6 +505,14 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 800px">
+						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL*</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -466,6 +522,20 @@
 					</div>
 					<div class="if2 placeholder">
 						<iframe loading="lazy" src="https://cdn.fmi.fi/demos/eumetnet-web-site-radar-animator/" frameborder="0" scrolling="no"></iframe>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
 					</div>
 				</td>
 			</tr>
@@ -498,6 +568,19 @@
 						<span class="indicator active"></span>
 						<span class="indicator"></span>
 
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 768px">
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
 					</div>
 				</td>
 			</tr>
@@ -546,6 +629,13 @@
 						<span class="indicator"></span>
 						<span class="indicator"></span>
 						<span class="indicator"></span>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 760px">
+						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ*</a>
 					</div>
 				</td>
 			</tr>
@@ -606,6 +696,16 @@
 						<span class="indicator"></span>
 						<span class="indicator"></span>
 						<span class="indicator"></span>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ*</a>
+						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin*</a>
+						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no*</a>
+						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale*</a>
 					</div>
 				</td>
 			</tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -446,7 +446,7 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
-						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung | Munje</a>
+						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
@@ -463,8 +463,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
@@ -905,7 +905,7 @@
 						</div>
 
 						<div class="item">
-							<p><b>Kvaliteta zraka</b></p>
+							<p><b><u>Kvaliteta zraka</u></b></p>
 							<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
 							<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
 							<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
@@ -913,14 +913,14 @@
 							<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
 							<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
 							<br />
-							<p><b>SpaceWeather</b></p>
+							<p><b><u>SpaceWeather</u></b></p>
 							<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
 							<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
 							<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
 							<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
 							<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
 							<br />
-							<p><b>Facebook</b></p>
+							<p><b><u>Facebook</u></b></p>
 							<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
 							<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
 							<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,23 +39,28 @@
 		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
 		{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
-		-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}
-		@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{
-		margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer
-		;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;
-		justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top
-		:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{
-		left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
-		color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{
-		opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{
-		display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;
-		transition:background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position
-		:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
-		width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
-		2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
-		max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
-		0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
+		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+		margin-right:-24px;background:linear-gradient(to left,transparent,#6e2424)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#6e2424)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;transition:
+		background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
+		justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
+		height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
+		font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height
+		 .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;
+		text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
 		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
 		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
 		width .3s ease-in-out}
@@ -84,12 +89,16 @@
 		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
 		o=e.touches[0].clientY),i=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?i=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o
-		;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o
+		;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}let previousWidth=0;function updateIframeSrc(){
+		e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+		e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
+		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
+		document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
+		updateLinksScrollShadows()}let previousWidth=0;function updateIframeSrc(){
 		window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
@@ -105,7 +114,7 @@
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
 		;const n=e.querySelector(".hint");let r=0,i=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(i=e.touches[0].clientX,
 		r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,a=Math.abs(t-i),s=Math.abs(o-r);a<10&&s<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,s=Math.abs(t-i),a=Math.abs(o-r);s<10&&a<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -126,8 +135,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),
-		window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),addLinksScrollShadows()}),window.addEventListener("resize",()=>{
+		clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText(),updateLinksScrollShadows()
+		},200)});
 	</script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>
 	<script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -194,14 +194,14 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -236,11 +236,11 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -275,13 +275,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -316,12 +316,12 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -349,13 +349,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -386,14 +386,14 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 720px">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -431,12 +431,12 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 768px">
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
 				</td>
 			</tr>
@@ -464,8 +464,8 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung</a>
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
-						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -500,7 +500,7 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 900px">
 						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
+						· <a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>
@@ -551,13 +551,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -597,12 +597,12 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 768px">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -725,11 +725,11 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a>
-						<a href="https://vrijeme-i-promet.hrt.hr/vrijeme/" target="_blank" rel="nofollow">HRT Vrijeme</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
-						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
-						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
-						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://vrijeme-i-promet.hrt.hr/vrijeme/" target="_blank" rel="nofollow">HRT Vrijeme</a>
+						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						· <a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
+						· <a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -411,7 +411,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
+					<div class="radartitle" style="max-width: 900px;">
+						<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="16" data-current-slide="2" style="max-width: 900px; aspect-ratio: 900 / 600;">
 						<div class="slide fade">
 							<img data-src="https://meteo-data.jurakovic.workers.dev/essl/img1.png" class="lazy" />
@@ -436,7 +438,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX | Prognoza nevremena</a>
+					<div class="radartitle" style="max-width: 800px;">
+						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX | Prognoza nevremena</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="18" data-current-slide="1" style="max-width: 800px; aspect-ratio: 1;">
 						<div class="slide fade active">
 							<img src="https://meteo-data.jurakovic.workers.dev/estofex/img1.png" />
@@ -471,13 +475,17 @@
 				<td align="center">
 					<div class="slideshow" data-slideshow-id="5" data-current-slide="1" style="max-width: 768px;">
 						<div class="slide fade active">
-							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img src="https://modeles20.meteociel.fr/satellite/animsatirmtgeu.gif" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img data-src="https://modeles20.meteociel.fr/satellite/latestsatirmtgeu.png" class="lazy" />
 							</div>
@@ -499,25 +507,33 @@
 				<td align="center">
 					<div class="slideshow" data-slideshow-id="17" data-current-slide="1" data-dynamic-width style="max-width: 760px;">
 						<div class="slide fade active">
-							<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 492;">
 								<img src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/analyza.gif" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 435; ">
 								<img data-src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/preba/preba36.gif" class="lazy" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 435; ">
 								<img data-src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/preba/preba60.gif" class="lazy" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 435; ">
 								<img data-src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/preba/preba84.gif" class="lazy" />
 							</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,36 +28,37 @@
 		body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
 		text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto;table-layout:fixed}.placeholder{
 		background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
-		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute
-		;right:0;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{
-		max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px)
-		{.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;
-		pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){
-		.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}
-		.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe
-		,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:
-		calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:
-		calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;
-		padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}
-		.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%
-		;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;
-		align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{
-		position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:
-		absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:
-		.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));
-		color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
-		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
-		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-		1px}.indicator{height:5px;background-color:#ffffff40;transition:background-color .3s}.indicator.active{background-color:#fff}
-		@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
+		position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
+		text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;
+		padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}
+		.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
+		background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
+		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
+		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
+		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
+		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
+		{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+		-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}
+		@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{
+		margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer
+		;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;
+		justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top
+		:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{
+		left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
+		color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{
+		opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{
+		display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;
+		transition:background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position
+		:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
+		width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
+		2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
+		max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
+		0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
+		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
+		width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -187,7 +188,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -268,7 +269,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -341,7 +342,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -379,7 +380,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -423,7 +424,7 @@
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
@@ -544,7 +545,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -818,7 +819,7 @@
 								<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
-								<b>Weather&Radar</b>
+								<b>Vrijeme&Radar</b>
 								<br />Satelit i radar
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,23 +48,24 @@
 		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
 		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
 		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}.slideshow{position:
-		relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
-		align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
-		user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
-		text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
-		linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
-		animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-		.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{
-		height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}@media (max-width:800px){
-		.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff
-		;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}
-		.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;
-		gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){
-		border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{
-		margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;
-		margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{
-		width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,16 +54,16 @@
 		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#4e5264;transition:
-		background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
-		justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
-		height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
-		font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height
-		 .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;
-		text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
-		position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
-		0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
-		width .3s ease-in-out}
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:4px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -741,7 +741,7 @@
 							<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
 							<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
 							<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
-							<p><a href="https://www.meteoadriatic.net" target=" rel="nofollow">MeteoAdriatic</a></p>
+							<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
 							<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
 							<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
 							<br />
@@ -800,6 +800,24 @@
 								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
 							</p>
 							<p>
+								<b>Ventussky</b>
+								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
+								<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
+								<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
+								<b>Rain Viewer</b>
+								<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+								<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
+							</p>
+							<p>
 								<b>Weather&Radar</b>
 								<br />Satelit i radar
 								<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
@@ -811,8 +829,8 @@
 							<p>
 								<b>I'm Weather</b>
 								<br />Satelit i radar
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
-								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
+								<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
 							</p>
 							<p>
 								<b>Sat24.com</b>

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -151,8 +151,9 @@ iframe, video {
 .links-bottom {
 	font-size: 12px;
 	text-align: left;
-	background-color: #234e6d;
-	padding: 5px 0px;
+	background-color: #0060bf;
+	box-sizing: border-box;
+	padding: 5px 4px;
 }
 
 .sp {
@@ -288,7 +289,7 @@ iframe, video {
 }
 
 	.indicator.active {
-		background-color: #c7c7c7;
+		background-color: white;
 	}
 
 @media (max-width: 800px) {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -38,6 +38,7 @@ table {
 	max-width: 100%;
 	background-color: #1a55af;
 	box-sizing: border-box;
+	height: 23px;
 	padding: 4px 3px;
 }
 
@@ -247,7 +248,7 @@ iframe, video {
 	}
 
 	.prev.shorter {
-		top: 0.4em;
+		top: 23px;
 	}
 
 .next {
@@ -261,7 +262,7 @@ iframe, video {
 	}
 
 	.next.shorter {
-		top: 0.4em;
+		top: 23px;
 	}
 
 .fade {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -148,6 +148,13 @@ iframe, video {
 	}
 }
 
+.links-bottom {
+	font-size: 12px;
+	text-align: left;
+	background-color: #234e6d;
+	padding: 5px 0px;
+}
+
 .sp {
 	height: 12px;
 }

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -15,6 +15,14 @@ h2, a, td {
 	color: white;
 }
 
+a {
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
 table {
 	width: 100%;
 	max-width: 875px;
@@ -28,6 +36,9 @@ table {
 .radartitle {
 	position: relative;
 	max-width: 100%;
+	background-color: #1a55af;
+	box-sizing: border-box;
+	padding: 4px 3px;
 }
 
 	.radartitle .center {
@@ -150,7 +161,7 @@ iframe, video {
 
 .links-bottom {
 	text-align: left;
-	background-color: #0060bf;
+	background-color: #9b1f1f;
 	box-sizing: border-box;
 	padding: 5px 4px;
 }

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -149,11 +149,11 @@ iframe, video {
 }
 
 .sp {
-	height: 10px;
+	height: 12px;
 }
 
 .sp30 {
-	height: 30px;
+	height: 28px;
 }
 
 .buttons {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -152,6 +152,10 @@ iframe, video {
 	height: 10px;
 }
 
+.sp30 {
+	height: 30px;
+}
+
 .buttons {
 	display: grid;
 	grid-template-columns: 49.5% 49.5%;
@@ -271,7 +275,7 @@ iframe, video {
 }
 
 .indicator {
-	height: 3px;
+	height: 4px;
 	background-color: #5c5c5c80;
 	transition: background-color 0.3s;
 }

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -149,11 +149,16 @@ iframe, video {
 }
 
 .links-bottom {
-	font-size: 12px;
 	text-align: left;
 	background-color: #0060bf;
 	box-sizing: border-box;
 	padding: 5px 4px;
+}
+
+@media (max-width: 800px) {
+	.links-bottom {
+		font-size: 12px;
+	}
 }
 
 .sp {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -170,7 +170,7 @@ iframe, video {
 
 .links-bottom {
 	text-align: left;
-	background-color: #6e2424;
+	background-color: #3a3f4a;
 	box-sizing: border-box;
 	padding: 5px 4px;
 	white-space: nowrap;
@@ -202,13 +202,13 @@ iframe, video {
 	.links-bottom::before {
 		left: -4px;
 		margin-right: -24px;
-		background: linear-gradient(to left, transparent, #6e2424);
+		background: linear-gradient(to left, transparent, #3a3f4a);
 	}
 
 	.links-bottom::after {
 		right: -4px;
 		margin-left: -24px;
-		background: linear-gradient(to right, transparent, #6e2424);
+		background: linear-gradient(to right, transparent, #3a3f4a);
 	}
 
 	.links-bottom.can-scroll-left::before {
@@ -361,7 +361,7 @@ iframe, video {
 
 .indicator {
 	height: 5px;
-	background-color: #ffffff40;
+	background-color: #4e5264;
 	transition: background-color 0.3s;
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -169,6 +169,7 @@ iframe, video {
 }
 
 .links-bottom {
+	display: none;
 	text-align: left;
 	background-color: #3a3f4a;
 	box-sizing: border-box;
@@ -219,6 +220,10 @@ iframe, video {
 		opacity: 1;
 	}
 
+	body.show-links-bottom .links-bottom {
+		display: block;
+	}
+
 @media (max-width: 800px) {
 	.links-bottom {
 		font-size: 12px;
@@ -263,6 +268,19 @@ iframe, video {
 
 		.buttons .btn:hover {
 			background-color: #5F6F89;
+		}
+
+	.links-btn {
+		position: relative;
+	}
+
+		.links-btn .links-toggle {
+			position: absolute;
+			right: 8px;
+			top: 22px;
+			transform: translateY(-50%);
+			margin: 0;
+			cursor: pointer;
 		}
 
 .slideshow {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -27,6 +27,7 @@ table {
 	width: 100%;
 	max-width: 875px;
 	height: auto;
+	table-layout: fixed;
 }
 
 .placeholder {
@@ -170,6 +171,9 @@ iframe, video {
 	background-color: #8c2c2c;
 	box-sizing: border-box;
 	padding: 5px 4px;
+	white-space: nowrap;
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
 }
 
 @media (max-width: 800px) {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -190,6 +190,12 @@ iframe, video {
 	height: 24px;
 }
 
+@media (max-width: 800px) {
+	.sp20 {
+		height: 12px;
+	}
+}
+
 .buttons {
 	display: grid;
 	grid-template-columns: 49.5% 49.5%;

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -51,11 +51,13 @@ table {
 	.radartitle .left {
 		position: absolute;
 		left: 0;
+		margin-left: 3px;
 	}
 
 	.radartitle .right {
 		position: absolute;
 		right: 0;
+		margin-right: 3px;
 		text-decoration: none;
 	}
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -359,7 +359,7 @@ iframe, video {
 }
 
 .indicator {
-	height: 4px;
+	height: 3px;
 	background-color: #4e5264;
 	transition: background-color 0.3s;
 }
@@ -370,7 +370,7 @@ iframe, video {
 
 @media (max-width: 800px) {
 	.indicator {
-		height: 3px;
+		height: 2px;
 	}
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -283,6 +283,16 @@ iframe, video {
 			cursor: pointer;
 		}
 
+			.links-btn .links-toggle::before {
+				content: '';
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
+				width: 28px;
+				height: 28px;
+			}
+
 .slideshow {
 	position: relative;
 	display: flex;

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -304,7 +304,7 @@ iframe, video {
 	}
 
 		.prev.shorter, .next.shorter {
-			top: 0.72em;
+			top: 23px;
 		}
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -182,8 +182,8 @@ iframe, video {
 	height: 12px;
 }
 
-.sp30 {
-	height: 28px;
+.sp20 {
+	height: 24px;
 }
 
 .buttons {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -19,9 +19,9 @@ a {
 	text-decoration: none;
 }
 
-a:hover {
-	text-decoration: underline;
-}
+	a:hover {
+		text-decoration: underline;
+	}
 
 table {
 	width: 100%;
@@ -250,6 +250,7 @@ iframe, video {
 	.prev:hover {
 		background-image: linear-gradient(to left, transparent, rgba(0,0,0,0.6));
 		color: white;
+		text-decoration: none;
 	}
 
 	.prev.shorter {
@@ -264,6 +265,7 @@ iframe, video {
 	.next:hover {
 		background-image: linear-gradient(to right, transparent, rgba(0,0,0,0.6));
 		color: white;
+		text-decoration: none;
 	}
 
 	.next.shorter {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -317,8 +317,8 @@ iframe, video {
 }
 
 .indicator {
-	height: 4px;
-	background-color: #5c5c5c80;
+	height: 5px;
+	background-color: #ffffff40;
 	transition: background-color 0.3s;
 }
 
@@ -328,7 +328,7 @@ iframe, video {
 
 @media (max-width: 800px) {
 	.indicator {
-		height: 2px;
+		height: 3px;
 	}
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -356,17 +356,16 @@ iframe, video {
 	grid-template-columns: repeat(3, 1fr);
 	gap: 4px;
 	width: 100%;
-	margin-top: 1px;
 }
 
 .indicator {
-	height: 5px;
+	height: 4px;
 	background-color: #4e5264;
 	transition: background-color 0.3s;
 }
 
 	.indicator.active {
-		background-color: white;
+		background-color: #ff9800;
 	}
 
 @media (max-width: 800px) {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -36,7 +36,7 @@ table {
 .radartitle {
 	position: relative;
 	max-width: 100%;
-	background-color: #1a55af;
+	background-color: #2b5797;
 	box-sizing: border-box;
 	height: 23px;
 	padding: 4px 3px;
@@ -167,7 +167,7 @@ iframe, video {
 
 .links-bottom {
 	text-align: left;
-	background-color: #9b1f1f;
+	background-color: #8c2c2c;
 	box-sizing: border-box;
 	padding: 5px 4px;
 }

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -168,7 +168,7 @@ iframe, video {
 
 .links-bottom {
 	text-align: left;
-	background-color: #8c2c2c;
+	background-color: #6e2424;
 	box-sizing: border-box;
 	padding: 5px 4px;
 	white-space: nowrap;

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -176,7 +176,48 @@ iframe, video {
 	white-space: nowrap;
 	overflow-x: auto;
 	-webkit-overflow-scrolling: touch;
+	scrollbar-width: none;
+	-ms-overflow-style: none;
 }
+
+	.links-bottom::-webkit-scrollbar {
+		display: none;
+	}
+
+	.links-bottom::before,
+	.links-bottom::after {
+		content: "";
+		position: sticky;
+		display: inline-block;
+		width: 24px;
+		height: 1.4em;
+		margin-top: -0.3em;
+		margin-bottom: -0.3em;
+		vertical-align: middle;
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 0.2s ease;
+	}
+
+	.links-bottom::before {
+		left: -4px;
+		margin-right: -24px;
+		background: linear-gradient(to left, transparent, #6e2424);
+	}
+
+	.links-bottom::after {
+		right: -4px;
+		margin-left: -24px;
+		background: linear-gradient(to right, transparent, #6e2424);
+	}
+
+	.links-bottom.can-scroll-left::before {
+		opacity: 1;
+	}
+
+	.links-bottom.can-scroll-right::after {
+		opacity: 1;
+	}
 
 @media (max-width: 800px) {
 	.links-bottom {

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -9,21 +9,21 @@ position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:rel
 position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-10px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size
-:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline
-:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{right:0;text-align:right}
-.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em}.fade{animation-name:
-fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-1px}.indicator{height:3px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#c7c7c7}
-@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
-2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;bottom:0;width:100%;height:2px;z-index:1000;
-background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
+margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;
+height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:
+center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;
+width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;
+text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:.4em}.next{
+right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:.4em
+}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{
+background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:
+10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;
+display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:
+5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){
+.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;
+color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;bottom:0;width:100%;height:2px;z-index:
+1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -8,8 +8,9 @@ background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{t
 position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
 position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.sp{height:
-12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
+@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
+{text-align:left;background-color:#0060bf;box-sizing:border-box;padding:5px 4px}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{
+height:12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;
 margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;
 height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:
 center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;
@@ -19,8 +20,8 @@ right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,t
 }.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
 12px;font-size:20px}.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
 width:100%;margin-top:1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{
-background-color:#c7c7c7}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:
-10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+background-color:#fff}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;
+margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}
 .expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;
 display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:
 5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -11,12 +11,12 @@ position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:rel
 position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+{text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
 -webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
 .links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
 margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-margin-right:-24px;background:linear-gradient(to left,transparent,#6e2424)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-linear-gradient(to right,transparent,#6e2424)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
 1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
 .buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
 ;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
@@ -27,7 +27,7 @@ background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
 text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 .next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 @media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;transition:
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#4e5264;transition:
 background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
 justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
 height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -1,28 +1,29 @@
 body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
-text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}
-.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
-transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
-none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
-display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}
-.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;
-position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;
-min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;
-width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
-;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
-calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
-calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;padding:5px 4px}
-@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5% 
-49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
-#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}
-.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{
-background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff}.next.shorter{top:23px}.fade{animation-name:fade;
+text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto;table-layout:fixed}.placeholder{
+background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
+ 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute
+;right:0;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{
+max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px)
+{.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;
+pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){
+.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}
+.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe
+,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:
+calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:
+calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;
+padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}
+.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%
+;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;
+align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{
+position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:
+absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:
+.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));
+color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
+linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
 animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-.next.shorter,.prev.shorter{top:.72em}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-1px}.indicator{height:4px;background-color:#5c5c5c80;transition:background-color .3s}.indicator.active{background-color:#fff}
-@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
+1px}.indicator{height:5px;background-color:#ffffff40;transition:background-color .3s}.indicator.active{background-color:#fff}
+@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
 font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
 background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
 grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -21,20 +21,21 @@ linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::bef
 24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
 {margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
 pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}.slideshow{position:
-relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
-align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
-user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
-text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
-linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
-animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{
-height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}@media (max-width:800px){
-.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff
-;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}
-.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;
-gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){
-border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{
-margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;
-margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{
-width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
+2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -27,13 +27,13 @@ background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
 text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 .next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 @media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#4e5264;transition:
-background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
-justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
-height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
-font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height
- .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;
-text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
-position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
-0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
-width .3s ease-in-out}
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:4px;background-color:#4e5264;transition:background-color .3s}
+.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:
+center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
+ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -12,23 +12,28 @@ position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{positi
 100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
 {text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
--webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}
-@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{
-margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer
-;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;
-justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top
-:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{
-left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
-color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{
-opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{
-display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;
-transition:background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position
-:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
-width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
-2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
-max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
-0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
+.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+margin-right:-24px;background:linear-gradient(to left,transparent,#6e2424)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+linear-gradient(to right,transparent,#6e2424)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;transition:
+background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;
+justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;
+height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;
+font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height
+ .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;
+text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
 position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
 0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
 width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -27,8 +27,8 @@ background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
 text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
 .next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
 @media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:4px;background-color:#4e5264;transition:background-color .3s}
-.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
 center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
 border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
 .links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -1,6 +1,6 @@
 body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
 text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto}.placeholder{background-color:#202c40}
-.radartitle{position:relative;max-width:100%;background-color:#1a55af;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
+.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px 3px}.radartitle .center{
 transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute;right:0;text-decoration:
 none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;
 display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}
@@ -10,7 +10,7 @@ min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%
 width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute
 ;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
 calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
-calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#9b1f1f;box-sizing:border-box;padding:5px 4px}
+calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;padding:5px 4px}
 @media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5% 
 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
 #485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -11,7 +11,7 @@ width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;ov
 ;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:
 calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:
 calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#9b1f1f;box-sizing:border-box;padding:5px 4px}
-@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp30{height:28px}.buttons{display:grid;grid-template-columns:49.5% 
+@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}.buttons{display:grid;grid-template-columns:49.5% 
 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:
 #485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}
 .slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -11,29 +11,30 @@ position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:rel
 position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
 100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-{text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
 -webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
 .links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
 margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
 margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
 linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-1}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
-ease-in-out}
+1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}.slideshow{position:
+relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;
+align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;
+user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;
+text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
+linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
+animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
+.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{
+height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}@media (max-width:800px){
+.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff
+;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}
+.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;
+gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){
+border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{
+margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;
+margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{
+width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -1,33 +1,34 @@
 body{background-color:#212f45;font-family:monospace;min-height:100vh;margin:0;padding:0}.container{margin:8px}a,h2,td{color:#fff}a{
 text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-width:875px;height:auto;table-layout:fixed}.placeholder{
 background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
- 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0}.radartitle .right{position:absolute
-;right:0;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{text-decoration:none;cursor:pointer}img{
-max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px)
-{.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;
-pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){
-.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}
-.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe
-,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:
-calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:
-calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom{text-align:left;background-color:#8c2c2c;box-sizing:border-box;
-padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}
-.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%
-;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;
-align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{
-position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:
-absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:
-.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));
-color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:
-linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;
-animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}
-.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:
-1px}.indicator{height:5px;background-color:#ffffff40;transition:background-color .3s}.indicator.active{background-color:#fff}
-@media (max-width:800px){.indicator{height:3px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
-2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+ 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
+position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
+text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;
+padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}
+.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
+background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
+position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
+position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
+100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
+@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
+{text-align:left;background-color:#6e2424;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
+-webkit-overflow-scrolling:touch}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}
+@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{
+margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer
+;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.slideshow{position:relative;display:flex;
+justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top
+:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{
+left:0;text-align:left}.prev:hover{background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+.prev.shorter{top:23px}.next{right:0;text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));
+color:#fff;text-decoration:none}.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{
+opacity:1}}@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{
+display:grid;grid-template-columns:repeat(3,1fr);gap:4px;width:100%;margin-top:1px}.indicator{height:5px;background-color:#ffffff40;
+transition:background-color .3s}.indicator.active{background-color:#fff}@media (max-width:800px){.indicator{height:3px}}.expandable{position
+:relative;justify-content:center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;
+width:100%;height:24px;border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:
+2px;font-size:14px}.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:
+max-height .3s ease-out}.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:
+0;text-align:left}@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{
+position:sticky;top:100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:
+0;top:0;width:100%;height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:
+width .3s ease-in-out}

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -44,6 +44,19 @@ function addExpandableClickEventListener() {
 	});
 }
 
+function toggleLinksBottom(checkbox) {
+	document.body.classList.toggle('show-links-bottom', checkbox.checked);
+	localStorage.setItem('showLinksBottom', checkbox.checked ? '1' : '0');
+	updateLinksScrollShadows();
+}
+
+function initLinksBottom() {
+	const checkbox = document.querySelector('.links-toggle');
+	if (!checkbox) return;
+	checkbox.checked = localStorage.getItem('showLinksBottom') === '1';
+	document.body.classList.toggle('show-links-bottom', checkbox.checked);
+}
+
 function plusSlides(slideshowId, n) {
 	const slideshow = document.querySelector(`.slideshow[data-slideshow-id="${slideshowId}"]`);
 	showSlides(slideshow, parseInt(slideshow.getAttribute('data-current-slide')) + n);
@@ -463,6 +476,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	updateIframeSrc();
 	hideOverlayOnDoubleTap();
 	updateHintText();
+	initLinksBottom();
 	addLinksScrollShadows();
 });
 

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -230,6 +230,24 @@ function addSwipeEvents() {
 	});
 }
 
+function updateLinksScrollShadow(bar) {
+	const max = bar.scrollWidth - bar.clientWidth;
+	const left = bar.scrollLeft;
+	bar.classList.toggle('can-scroll-left', left > 1);
+	bar.classList.toggle('can-scroll-right', max > 1 && left < max - 1);
+}
+
+function updateLinksScrollShadows() {
+	document.querySelectorAll('.links-bottom').forEach(updateLinksScrollShadow);
+}
+
+function addLinksScrollShadows() {
+	document.querySelectorAll('.links-bottom').forEach(bar => {
+		bar.addEventListener('scroll', () => updateLinksScrollShadow(bar), { passive: true });
+	});
+	updateLinksScrollShadows();
+}
+
 let previousWidth = 0;
 
 function updateIframeSrc() {
@@ -445,6 +463,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	updateIframeSrc();
 	hideOverlayOnDoubleTap();
 	updateHintText();
+	addLinksScrollShadows();
 });
 
 window.addEventListener('resize', () => {
@@ -452,5 +471,6 @@ window.addEventListener('resize', () => {
 	window._resizeTimeout = setTimeout(() => {
 		updateIframeSrc();
 		updateHintText();
+		updateLinksScrollShadows();
 	}, 200);
 });

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -21,12 +21,16 @@ const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1)
 document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
 o=e.touches[0].clientY),i=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?i=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,a=r-o
-;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o
+;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",a=>{if(i){n=a.clientX,r=a.clientY;const s=n-t,d=r-o;Math.abs(s)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}let previousWidth=0;function updateIframeSrc(){
+e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
+e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
+document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
+document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
+updateLinksScrollShadows()}let previousWidth=0;function updateIframeSrc(){
 window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
@@ -42,7 +46,7 @@ if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),
 ;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
 ;const n=e.querySelector(".hint");let r=0,i=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(i=e.touches[0].clientX,
 r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,a=Math.abs(t-i),s=Math.abs(o-r);a<10&&s<10&&(n.style.opacity="0.6",
+;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,s=Math.abs(t-i),a=Math.abs(o-r);s<10&&a<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -63,5 +67,6 @@ function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),
-window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText()},200)});
+updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),addLinksScrollShadows()}),window.addEventListener("resize",()=>{
+clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText(),updateLinksScrollShadows()
+},200)});

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -4,12 +4,16 @@ document.querySelector(".expandable").addEventListener("click",function(){let e=
 ;const t=document.querySelector(".links");t.style.maxHeight?(t.style.maxHeight=null,
 e.textContent="▼"):(t.style.maxHeight=t.scrollHeight+"px",e.textContent="▲",setTimeout(()=>{
 document.documentElement.style.scrollBehavior="auto",document.body.style.scrollBehavior="auto",scrollToElement("links"),setTimeout(()=>{
-document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}function plusSlides(e,t){
+document.documentElement.style.scrollBehavior="smooth",document.body.style.scrollBehavior="smooth"},50)},310))})}
+function toggleLinksBottom(e){document.body.classList.toggle("show-links-bottom",e.checked),
+localStorage.setItem("showLinksBottom",e.checked?"1":"0"),updateLinksScrollShadows()}function initLinksBottom(){
+const e=document.querySelector(".links-toggle");e&&(e.checked="1"===localStorage.getItem("showLinksBottom"),
+document.body.classList.toggle("show-links-bottom",e.checked))}function plusSlides(e,t){
 const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 function showSlides(e,t){
 const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-;let i=t;i>n.length&&(i=1),i<1&&(i=n.length),e.setAttribute("data-current-slide",i),n.forEach(e=>e.classList.remove("active")),
-n[i-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[i-1].classList.add("active"),updateSlideshowWidth(e)}
+;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
+n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
 function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 ;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 ;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -18,15 +22,15 @@ const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar
 e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,i=!1;e.querySelectorAll("img").forEach(e=>{
+document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
-o=e.touches[0].clientY),i=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?i=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-Math.abs(n-t)>Math.abs(r-o)&&(i=!0))}),e.addEventListener("touchend",()=>{if(i){const i=n-t,s=r-o
-;Math.abs(i)>Math.abs(s)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+o=e.touches[0].clientY),s=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?s=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
+Math.abs(n-t)>Math.abs(r-o)&&(s=!0))}),e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o
+;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
-e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,i=!0}),e.addEventListener("mousemove",e=>{i&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",s=>{if(i){n=s.clientX,r=s.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),i=!1}}),
-e.addEventListener("mouseleave",()=>{i&&(i=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
+e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
+e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 ;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
@@ -42,11 +46,11 @@ t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getRe
 ;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
 let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
 setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),i=r-t;if(i>0&&i<200){e.style.display="none"
+if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),s=r-t;if(s>0&&s<200){e.style.display="none"
 ;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
-;const n=e.querySelector(".hint");let r=0,i=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(i=e.touches[0].clientX,
+;const n=e.querySelector(".hint");let r=0,s=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(s=e.touches[0].clientX,
 r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,s=Math.abs(t-i),a=Math.abs(o-r);s<10&&a<10&&(n.style.opacity="0.6",
+;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-s),a=Math.abs(o-r);i<10&&a<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -67,6 +71,6 @@ function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),addLinksScrollShadows()}),window.addEventListener("resize",()=>{
-clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),updateHintText(),updateLinksScrollShadows()
-},200)});
+updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
+updateHintText(),updateLinksScrollShadows()},200)});

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -92,7 +92,7 @@
 	<p>
 		<b>Blitzortung.org</b>
 		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://map.blitzortung.org/#6.5/44.5/16.6" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 		<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
 	</p>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -17,11 +17,11 @@
 	<p><a href="https://charts.ecmwf.int" target="_blank" rel="nofollow">ECMWF</a></p>
 	<p><a href="https://www.wxcharts.com" target="_blank" rel="nofollow">WXCharts</a></p>
 	<br />
-	<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,45.799,15.937,8" target="_blank" rel="nofollow">Windy</a></p>
+	<p><a href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a></p>
 	<p><a href="https://meteo.arso.gov.si" target="_blank" rel="nofollow">meteo.si</a></p>
 	<p><a href="https://www.wetterzentrale.de/en/" target="_blank" rel="nofollow">Wetterzentrale</a></p>
 	<p><a href="https://www.meteociel.fr" target="_blank" rel="nofollow">Meteociel.fr</a></p>
-	<p><a href="https://zoom.earth" target="_blank" rel="nofollow">Zoom Earth</a></p>
+	<p><a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a></p>
 	<p><a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a></p>
 </div>
 
@@ -58,16 +58,16 @@
 	<p>
 		<b>I'm Weather</b>
 		<br />Satelit i radar
-		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=45.0000&lng=17.0000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
 		<b>meteoblue</b>
 		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/45/17" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/45/17" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
@@ -75,9 +75,11 @@
 	<p>
 		<b>Weather&Radar</b>
 		<br />Satelit i radar
-		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44,16&placemark=45.8144,15.978&zoom=5&layer=wr" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
 		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44,16&placemark=45.8144,15.978&zoom=5&layer=tr" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
 		<b>Időkép</b>
@@ -90,14 +92,14 @@
 	<p>
 		<b>Blitzortung.org</b>
 		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://map.blitzortung.org/#6.5/45/16" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://map.blitzortung.org/#6.5/44.5/16.6" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://map.blitzortung.org/#4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 		<a href="https://www.blitzortung.org/en/live_lightning_maps.php?map=10" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
 		<b>LightningMaps.org</b>
 		<br />Munje&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=45;x=17;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">Europa</a>
 		<a href="https://www.lightningmaps.org/blitzortung/europe/index.php?bo_page=archive&lang=en&bo_map=0&bo_animation=now" target="_blank" rel="nofollow">Europa</a>
 	</p>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -94,8 +94,8 @@
 	<p>
 		<b>I'm Weather</b>
 		<br />Satelit i radar
-		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">Hrvatska</a>
-		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.20" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
 		<b>Sat24.com</b>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -139,10 +139,10 @@
 		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Europa</a>
 		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
+		<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Zagreb</a>
 		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
-		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
-		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ico&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
+		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.wetterzentrale.de/en/topkarten.php?map=1&model=ecm&var=5&time=0&run=6&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
 		<b>Meteociel.fr</b>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -65,7 +65,7 @@
 		<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
 	</p>
 	<p>
-		<b>Ventussky</b>
+		<b>Ventusky</b>
 		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -6,7 +6,7 @@
 	<p><a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a></p>
 	<p><a href="https://www.istramet.hr/" target="_blank" rel="nofollow">Istramet</a></p>
 	<p><a href="https://www.crometeo.hr/forum/index.php" target="_blank" rel="nofollow">Crometeo forum</a></p>
-	<p><a href="https://www.meteoadriatic.net" target=" rel="nofollow">MeteoAdriatic</a></p>
+	<p><a href="https://www.meteoadriatic.net" target="_blank" rel="nofollow">MeteoAdriatic</a></p>
 	<p><a href="https://meteoalarm.org/en/live/region/HR" target="_blank" rel="nofollow">Meteoalarm</a></p>
 	<p><a href="https://nebo.com.hr" target="_blank" rel="nofollow">Nebo.com.hr</a></p>
 	<br />
@@ -63,6 +63,24 @@
 		<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~sat~none~none~none&coords=4.2/47.5/17.5" target="_blank" rel="nofollow">Europa</a>
 		<br />Prognoza&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 		<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">Zagreb</a>
+	</p>
+	<p>
+		<b>Ventussky</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Europa</a>
+		<br />Satelit&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Europa</a>
+		<br />Temperatura&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=temperature-2m&w=off" target="_blank" rel="nofollow">Europa</a>
+	</p>
+	<p>
+		<b>Rain Viewer</b>
+		<br />Radar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+		<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Hrvatska</a>
+		<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
 		<b>Weather&Radar</b>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -159,7 +159,7 @@
 </div>
 
 <div class="item">
-	<p><b>Kvaliteta zraka</b></p>
+	<p><b><u>Kvaliteta zraka</u></b></p>
 	<p><a href="https://meteo.hr/kvaliteta_zraka.php?section=podaci_kz&post=Zagreb%204&id_komp=259&komp=lebdece%20cestice%20(%3C2.5um)" target="_blank" rel="nofollow">DHMZ</a></p>
 	<p><a href="https://iszz.azo.hr/iskzl/" target="_blank" rel="nofollow">MZOZT</a></p>
 	<p><a href="https://www.iqair.com/croatia/zagreb" target="_blank" rel="nofollow">IQAir</a></p>
@@ -167,14 +167,14 @@
 	<p><a href="https://weather.com/forecast/air-quality/l/af895d475e97eb1973a3b4f52250c3968596b1ef505137bb1390abcb637e6eee" target="_blank" rel="nofollow">The Weather Channel</a></p>
 	<p><a href="https://airquality.city/hr" target="_blank" rel="nofollow">AirQualityCity</a></p>
 	<br />
-	<p><b>SpaceWeather</b></p>
+	<p><b><u>SpaceWeather</u></b></p>
 	<p><a href="https://spaceweather.com" target="_blank" rel="nofollow">SpaceWeather.com</a></p>
 	<p><a href="https://www.spaceweatherlive.com/en.html" target="_blank" rel="nofollow">SpaceWeatherLive.com</a></p>
 	<p><a href="https://www.swpc.noaa.gov" target="_blank" rel="nofollow">Space Weather Prediction Center</a></p>
 	<p><a href="https://www.swpc.noaa.gov/products/aurora-30-minute-forecast" target="_blank" rel="nofollow">Aurora Forecast</a></p>
 	<p><a href="https://www.heavens-above.com/?lat=45.8&lng=16&loc=Zagreb&alt=122&tz=CET" target="_blank" rel="nofollow">Heavens-Above</a></p>
 	<br />
-	<p><b>Facebook</b></p>
+	<p><b><u>Facebook</u></b></p>
 	<p><a href="https://www.facebook.com/neverinhr" target="_blank" rel="nofollow">Neverin</a></p>
 	<p><a href="https://www.facebook.com/kadcekisa" target="_blank" rel="nofollow">Kad će Kiša</a></p>
 	<p><a href="https://www.facebook.com/crometeo2" target="_blank" rel="nofollow">Crometeo</a></p>

--- a/src/_components/links.c.html
+++ b/src/_components/links.c.html
@@ -83,7 +83,7 @@
 		<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Europa</a>
 	</p>
 	<p>
-		<b>Weather&Radar</b>
+		<b>Vrijeme&Radar</b>
 		<br />Satelit i radar
 		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Hrvatska</a>
 		<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Europa</a>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -32,22 +32,6 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather & Radar</a>
-						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
-					</div>
-					<div class="if1 placeholder">
-						<iframe id="weatherAndRadar" class="scaled-iframe" loading="eager" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
-						<div class="overlay" id="overlayWeatherAndRadarFrame">
-							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
-						</div>
-					</div>
-				</td>
-			</tr>
-			<tr class="sp"></tr>
-
-			<tr>
-				<td align="center">
-					<div class="radartitle">
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" style="display:none">[X]</a>
 					</div>
@@ -70,6 +54,22 @@
 					<div class="if1 placeholder">
 						<iframe id="ventussky" class="scaled-iframe" loading="lazy" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame">
+							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
+						</div>
+					</div>
+				</td>
+			</tr>
+			<tr class="sp"></tr>
+
+			<tr>
+				<td align="center">
+					<div class="radartitle">
+						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
+						<a class="right" id="resetWeatherAndRadarFrame" style="display:none">[X]</a>
+					</div>
+					<div class="if1 placeholder">
+						<iframe id="weatherAndRadar" class="scaled-iframe" loading="eager" data-src="https://radar.wo-cloud.com/pwa/?center=44.5,16.5&zoom=7.2&tz=Europe/Zagreb&tf=HH:mm&tempunit=celsius&windunit=kph&showShareButton=false&lang=en-US&placemarkName=Zagreb&desktop=true&fadeTop=true" frameborder="0"></iframe>
+						<div class="overlay" id="overlayWeatherAndRadarFrame">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -119,14 +119,14 @@
 			<tr class="sp"></tr>
 
 			<!--
-			<tr>
-				<td align="center">
-					<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép | Radar | Hrvatska</a>
-					<div class="vid2"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/idokepradar/public_radar_adria.mp4"></video></div>
-				</td>
-			</tr>
-			<tr class="sp"></tr>
-			 -->
+	<tr>
+		<td align="center">
+			<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép | Radar | Hrvatska</a>
+			<div class="vid2"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/idokepradar/public_radar_adria.mp4"></video></div>
+		</td>
+	</tr>
+	<tr class="sp"></tr>
+	 -->
 
 			<tr>
 				<td align="center">

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -64,11 +64,11 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar" target="_blank" rel="nofollow">Ventussky</a>
+						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a class="right" id="resetVentusskyFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="lazy" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar" frameborder="0"></iframe>
+						<iframe id="ventussky" class="scaled-iframe" loading="lazy" data-src="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" frameborder="0"></iframe>
 						<div class="overlay" id="overlayVentusskyFrame">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -48,11 +48,11 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=1&lm=1&layer=radar&sm=1&sn=2" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a class="right" id="resetRainViewerFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=1&lm=1&layer=radar&sm=1&sn=2" frameborder="0"></iframe>
+						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" data-src="https://www.rainviewer.com/map.html?loc=44.8,16.5,6.3&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" frameborder="0"></iframe>
 						<div class="overlay" id="overlayRainViewerFrame">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -104,7 +104,7 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
-						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
+						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -26,7 +26,10 @@
 				<td align="center">
 					<div class="buttons">
 						<a href="/" style="text-decoration: none"><div class="btn">Početna</div></a>
-						<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+						<div class="links-btn">
+							<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+							<input type="checkbox" class="links-toggle" onchange="toggleLinksBottom(this)" title="Prikaži linkove ispod karata" />
+						</div>
 					</div>
 				</td>
 			</tr>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -50,7 +50,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -70,7 +70,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -90,7 +90,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -113,7 +113,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -125,7 +125,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -137,7 +137,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<!--
 			<tr>
@@ -148,7 +148,7 @@
 					<div class="vid2"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/idokepradar/public_radar_adria.mp4"></video></div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 			 -->
 
 			<tr>
@@ -161,7 +161,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -173,7 +173,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -185,7 +185,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -197,7 +197,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -220,7 +220,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -243,7 +243,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -266,7 +266,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -289,7 +289,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -312,7 +312,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -335,7 +335,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center" id="links">

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -248,8 +248,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 804px">
-						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
@@ -259,7 +259,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung | Munje</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
 					</div>
 					<div class="placeholder" style="aspect-ratio: 1;">
 						<img src="https://www.blitzortung.org/Images/image_b_eu.png" />
@@ -269,8 +269,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.rg</a>
 						· <a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -54,13 +54,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -88,13 +88,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -122,13 +122,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -159,14 +159,14 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 821px">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -186,13 +186,13 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 840px">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -212,12 +212,12 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -249,8 +249,8 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 804px">
 						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
-						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -270,8 +270,8 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
-						<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						· <a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -291,13 +291,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
-						<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						· <a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
+						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
 				</td>
 			</tr>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -280,10 +280,10 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
+						<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ecm&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
 					</div>
 					<div class="placeholder" style="aspect-ratio: 959 / 741;">
-						<img src="https://www.wetterzentrale.de/en/create_gif.php?model=ICO&member=OP&var=5&map=IT&run=06&speed=250&times=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47" alt="Wetterzentrale Temperatura" />
+						<img src="https://www.wetterzentrale.de/en/create_gif.php?model=ECM&member=OP&var=5&map=IT&run=06&speed=250&times=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47" alt="Wetterzentrale Temperatura" />
 					</div>
 				</td>
 			</tr>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -94,7 +94,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.arso.gov.si/met/sl/weather/observ/radar/" target="_blank" rel="nofollow">meteo.si</a>
+					<div class="radartitle" style="max-width: 821px;">
+						<a href="https://meteo.arso.gov.si/met/sl/weather/observ/radar/" target="_blank" rel="nofollow">meteo.si</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="6" data-current-slide="1" style="max-width: 821px; aspect-ratio: 821 / 660; ">
 						<div class="slide fade active">
 							<img src="https://meteo.arso.gov.si/uploads/probase/www/observ/radar/si0-rm-anim.gif?nocache" />
@@ -115,7 +117,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Időkép | Radar | Europa</a>
+					<div class="radartitle" style="max-width: 840px;">
+						<a href="https://www.idokep.eu/ceu/radar" target="_blank" rel="nofollow">Időkép | Radar | Europa</a>
+					</div>
 					<div class="placeholder" style="max-width: 840px; aspect-ratio: 840 / 600;">
 						<img src="https://www.idokep.eu/terkep/eu/radar.gif" />
 					</div>
@@ -125,7 +129,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.idokep.hu/muhold" target="_blank" rel="nofollow">Időkép | Satelit | Europa</a>
+					<div class="radartitle">
+						<a href="https://www.idokep.hu/muhold" target="_blank" rel="nofollow">Időkép | Satelit | Europa</a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 1070 / 713;">
 						<div class="vid1"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/radar/sat-eu.mp4"></video></div>
 					</div>
@@ -136,7 +142,9 @@
 			<!--
 			<tr>
 				<td align="center">
-					<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép | Radar | Hrvatska</a>
+					<div class="radartitle">
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép | Radar | Hrvatska</a>
+					</div>
 					<div class="vid2"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/idokepradar/public_radar_adria.mp4"></video></div>
 				</td>
 			</tr>
@@ -145,7 +153,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.istramet.hr/radari-munja/" target="_blank" rel="nofollow">Istramet | Munje</a>
+					<div class="radartitle" style="max-width: 804px;">
+						<a href="https://www.istramet.hr/radari-munja/" target="_blank" rel="nofollow">Istramet | Munje</a>
+					</div>
 					<div class="placeholder" style="max-width: 804px; aspect-ratio: 804 / 687; ">
 						<img src="https://www.istramet.hr/wp-content/themes/istramet/img/munje_hr.png" />
 					</div>
@@ -155,7 +165,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+					<div class="radartitle">
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 1;">
 						<img src="https://www.blitzortung.org/Images/image_b_eu.png" />
 					</div>
@@ -165,7 +177,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
+					<div class="radartitle">
+						<a href="https://www.wetterzentrale.de/en/topkarten.php?map=17&model=ico&var=5&run=6&time=0&lid=OP&h=1&mv=0&tr=1" target="_blank" rel="nofollow">Wetterzentrale | Temperatura </a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 959 / 741;">
 						<img src="https://www.wetterzentrale.de/en/create_gif.php?model=ICO&member=OP&var=5&map=IT&run=06&speed=250&times=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47" alt="Wetterzentrale Temperatura" />
 					</div>
@@ -175,7 +189,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ | Sinoptička karta</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ | Sinoptička karta</a>
+					</div>
 					<div class="placeholder" style="max-width: 720px; aspect-ratio: 1;">
 						<img src="https://prognoza.hr/web_fronte_sutra12.jpg" />
 					</div>
@@ -185,7 +201,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=puntijarka&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Puntijarka</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=puntijarka&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Puntijarka</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="8" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_puntijarka.gif" />
@@ -206,7 +224,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=bilogora&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Bilogora</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=bilogora&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Bilogora</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="9" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_bilogora.gif" />
@@ -227,7 +247,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=gradiste&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Gradište</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=gradiste&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Gradište</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="10" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_gradiste.gif" />
@@ -248,7 +270,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=goli&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Goli</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=goli&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Goli</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="11" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_goli.gif" />
@@ -269,7 +293,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=debeljak&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Debeljak</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=debeljak&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Debeljak</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="12" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_debeljak.gif" />
@@ -290,7 +316,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=uljenje&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Uljenje</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=uljenje&acto=anim" target="_blank" rel="nofollow">DHMZ | MRC Uljenje</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="13" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_uljenje.gif" />

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -57,7 +57,7 @@
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -91,7 +91,7 @@
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -163,7 +163,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -190,7 +190,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -294,7 +294,7 @@
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
 						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -50,6 +50,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -70,6 +84,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -87,6 +115,20 @@
 						<div class="overlay" id="overlayWeatherAndRadarFrame" data-frame-id="weatherAndRadar">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -113,6 +155,21 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 821px">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -125,6 +182,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 840px">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -134,6 +205,19 @@
 					</div>
 					<div class="placeholder" style="aspect-ratio: 1070 / 713;">
 						<div class="vid1"><video muted="" autoplay="" loop="" controls=""><source type="video/mp4" src="https://www.idokep.hu/radar/sat-eu.mp4"></video></div>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -161,15 +245,33 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 804px">
+						<a href="https://map.blitzortung.org/#6.5/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung | Munje</a>
 					</div>
 					<div class="placeholder" style="aspect-ratio: 1;">
 						<img src="https://www.blitzortung.org/Images/image_b_eu.png" />
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung</a>
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -185,6 +287,20 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -194,6 +310,13 @@
 					</div>
 					<div class="placeholder" style="max-width: 720px; aspect-ratio: 1;">
 						<img src="https://prognoza.hr/web_fronte_sutra12.jpg" />
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 720px">
+						<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ</a>
 					</div>
 				</td>
 			</tr>
@@ -335,7 +458,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp20"></tr>
+			<tr class="sp"></tr>
 
 			<tr>
 				<td align="center" id="links">

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -353,7 +353,7 @@
 		</table>
 	</div>
 	<footer>
-		<a onclick="scrollToTop()" style="cursor: pointer"><u>Povratak na vrh</u></a>
+		<a onclick="scrollToTop()" style="cursor: pointer">Povratak na vrh</a>
 		·
 		<a href="/">Početna</a>
 		|

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -38,16 +38,16 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventussky', this)">[HR]</a>
-						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a class="right" id="resetVentusskyFrame" data-frame-id="ventussky" style="display:none">[X]</a>
+						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventusky', this)">[HR]</a>
+						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
+						<a class="right" id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
-						<iframe id="ventussky" class="scaled-iframe" loading="eager" frameborder="0"
+						<iframe id="ventusky" class="scaled-iframe" loading="eager" frameborder="0"
 								data-src-hr="https://embed.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" data-zoom-hr-desktop=";6&" data-zoom-hr-mobile=";6&"
 								data-src-eu="https://embed.ventusky.com/?p=48.0;10.0;4&l=radar&w=off" data-zoom-eu-desktop=";4&" data-zoom-eu-mobile=";3&">
 						</iframe>
-						<div class="overlay" id="overlayVentusskyFrame" data-frame-id="ventussky">
+						<div class="overlay" id="overlayVentuskyFrame" data-frame-id="ventusky">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
 					</div>
@@ -93,7 +93,7 @@
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -128,7 +128,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -165,7 +165,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -192,7 +192,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
@@ -217,7 +217,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
@@ -273,7 +273,7 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.rg</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=5;y=47.5;x=17.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						· <a href="https://www.neverin.hr/munje/#:~:text=Pojava%20munja%20Europa" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
@@ -296,7 +296,7 @@
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						· <a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel</a>

--- a/src/index.html
+++ b/src/index.html
@@ -101,7 +101,7 @@
 					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -136,7 +136,7 @@
 					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -170,7 +170,7 @@
 					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -233,7 +233,18 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="center">
+					<div style="max-width: 768px; text-align:left">
+						<br /><b>></b>
+						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					</div>
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">
@@ -273,16 +284,16 @@
 			<tr class="sp"></tr>
 
 			<!--
-	<tr>
-		<td align="center">
-			<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
-			<div class="placeholder" style="max-width: 800px; aspect-ratio: 1;">
-				<img src="https://www.estofex.org/forecasts/tempmap/.png" />
-			</div>
-		</td>
-	</tr>
-	<tr class="sp"></tr>
-	-->
+			<tr>
+				<td align="center">
+					<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+					<div class="placeholder" style="max-width: 800px; aspect-ratio: 1;">
+						<img src="https://www.estofex.org/forecasts/tempmap/.png" />
+					</div>
+				</td>
+			</tr>
+			<tr class="sp"></tr>
+			-->
 
 			<tr>
 				<td align="center">

--- a/src/index.html
+++ b/src/index.html
@@ -63,7 +63,7 @@
 					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 					<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-					<!--<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>-->
+					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
 					<!--<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>-->
 				</td>
 			</tr>
@@ -134,6 +134,7 @@
 					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 					<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -241,6 +242,7 @@
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -55,7 +55,6 @@
 			<tr>
 				<td align="left">
 					<div class="links-bottom">
-						<b>></b>
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -93,7 +92,6 @@
 			<tr>
 				<td align="left">
 					<div class="links-bottom">
-						<b>></b>
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -129,7 +127,6 @@
 			<tr>
 				<td align="left">
 					<div class="links-bottom">
-						<b>></b>
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -167,7 +164,6 @@
 			<tr>
 				<td align="left">
 					<div class="links-bottom">
-						<b>></b>
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -239,9 +235,8 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom" style="max-width: 768px">
-						<b>></b>
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>

--- a/src/index.html
+++ b/src/index.html
@@ -52,7 +52,19 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr>
+				<td align="left">
+					<br /><b>Radar | Hrvatska :</b>
+					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<!--<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24.com</a>-->
+					<!--<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Meteoradar</a>-->
+					<!--<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">I'm Weather</a>-->
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
+					<!--<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>-->
+				</td>
+			</tr>
+			<tr class="sp30"></tr>
 
 			<tr>
 				<td align="center">

--- a/src/index.html
+++ b/src/index.html
@@ -249,7 +249,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a>
+						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						<a class="right" id="resetBlitzortungFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">

--- a/src/index.html
+++ b/src/index.html
@@ -53,8 +53,8 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
-					<br /><b>></b>
+				<td align="left" style="font-size: 12px; padding: 5px 0px; background-color: #234e6d">
+					<b>></b>
 					<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 					<!--<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24.com</a>-->
@@ -93,8 +93,8 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
-					<br /><b>></b>
+				<td align="left" style="font-size: 12px">
+					<b>></b>
 					<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 					<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -163,8 +163,8 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
-					<br /><b>></b>
+				<td align="left" style="font-size: 12px">
+					<b>></b>
 					<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 					<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
@@ -235,9 +235,9 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="center">
+				<td align="left" style="font-size: 12px">
 					<div style="max-width: 768px; text-align:left">
-						<br /><b>></b>
+						<b>></b>
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Hrvatska</a>
+					<div class="radartitle">
+						<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Hrvatska</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="1" style="aspect-ratio: 875 / 625;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/radar/latest_hr.webp" class="lazy" />
@@ -71,7 +73,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Hrvatska</a>
+					<div class="radartitle">
+						<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Hrvatska</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="2" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/sat/latest_vis_hr.webp" class="lazy" />
@@ -106,7 +110,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Europa</a>
+					<div class="radartitle">
+						<a href="https://www.neverin.hr/radar/" target="_blank" rel="nofollow">Neverin | Radar | Europa</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="3" style="aspect-ratio: 875 / 625;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/radar/latest_eu.webp" class="lazy" />
@@ -143,7 +149,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Europa</a>
+					<div class="radartitle">
+						<a href="https://www.neverin.hr/satelit/" target="_blank" rel="nofollow">Neverin | Satelit | Europa</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="4" style="aspect-ratio: 880 / 640;">
 						<div class="slide fade">
 							<img data-src="https://maps.neverin.hr/sat/latest_vis_eu.webp" class="lazy" />
@@ -194,7 +202,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | kompozit</a>
+					<div class="radartitle" style="max-width: 720px;">
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | kompozit</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="7" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
 							<img src="https://vrijeme.hr/anim_kompozit.gif" />
@@ -217,13 +227,17 @@
 				<td align="center">
 					<div class="slideshow" data-slideshow-id="15" style="max-width: 768px;">
 						<div class="slide fade active">
-							<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel.fr | Temperatura </a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=it" target="_blank" rel="nofollow">Meteociel.fr | Temperatura </a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img src="https://www.meteociel.fr/cartes_obs/temp_it.png" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=eur2" target="_blank" rel="nofollow">Meteociel.fr | Temperatura </a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/temperatures.php?region=eur2" target="_blank" rel="nofollow">Meteociel.fr | Temperatura </a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img data-src="https://www.meteociel.com/cartes_obs/temp_eur2.png" class="lazy" />
 							</div>
@@ -268,7 +282,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a> // <a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+					<div class="radartitle">
+						<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a> // <a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="16" style="aspect-ratio: 900 / 600;">
 						<div class="slide fade active">
 							<img src="https://weather.essl.org/storm/map_images/models/archamos/latest.png" />
@@ -288,20 +304,22 @@
 			<tr class="sp"></tr>
 
 			<!--
-		<tr>
-			<td align="center">
-				<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
-				<div class="placeholder" style="max-width: 800px; aspect-ratio: 1;">
-					<img src="https://www.estofex.org/forecasts/tempmap/.png" />
-				</div>
-			</td>
-		</tr>
-		<tr class="sp"></tr>
-		-->
+			<tr>
+				<td align="center">
+					<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+					<div class="placeholder" style="max-width: 800px; aspect-ratio: 1;">
+						<img src="https://www.estofex.org/forecasts/tempmap/.png" />
+					</div>
+				</td>
+			</tr>
+			<tr class="sp"></tr>
+			-->
 
 			<tr>
 				<td align="center">
-					<a href="https://www.eumetnet.eu/observations/opera-radar-animation/" target="_blank" rel="nofollow">EUMETNET</a>
+					<div class="radartitle">
+						<a href="https://www.eumetnet.eu/observations/opera-radar-animation/" target="_blank" rel="nofollow">EUMETNET</a>
+					</div>
 					<div class="if2 placeholder">
 						<iframe loading="lazy" src="https://cdn.fmi.fi/demos/eumetnet-web-site-radar-animator/" frameborder="0" scrolling="no"></iframe>
 					</div>
@@ -311,7 +329,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.meteociel.fr/observations-meteo/satellite.php" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+					<div class="radartitle" style="max-width: 768px;">
+						<a href="https://www.meteociel.fr/observations-meteo/satellite.php" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="5" style="max-width: 768px; aspect-ratio: 1;">
 						<div class="slide fade active">
 							<img src="https://neige.meteociel.fr/satellite/anim_ir.gif" />
@@ -332,7 +352,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.neverin.hr/kamere/" target="_blank" rel="nofollow">Neverin | Kamera | Zagreb-Remetinečki rotor</a>
+					<div class="radartitle">
+						<a href="https://www.neverin.hr/kamere/" target="_blank" rel="nofollow">Neverin | Kamera | Zagreb-Remetinečki rotor</a>
+					</div>
 					<div class="placeholder" style="aspect-ratio: 1280 / 720;">
 						<img src="https://webcams.neverin.hr/7332072588/latest.jpg" />
 					</div>
@@ -344,25 +366,33 @@
 				<td align="center">
 					<div class="slideshow" data-slideshow-id="14">
 						<div class="slide fade active">
-							<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">meteoblue | Prognoza | Zagreb</a>
+							<div class="radartitle">
+								<a href="https://www.meteoblue.com/en/weather/week/zagreb_croatia_3186886" target="_blank" rel="nofollow">meteoblue | Prognoza | Zagreb</a>
+							</div>
 							<div class="placeholder" style="aspect-ratio: 1152 / 963;">
 								<img src="https://my.meteoblue.com/images/meteogram?temperature_units=C&windspeed_units=kmh&precipitation_units=mm&darkmode=true&iso2=hr&lat=45.8144&lon=15.978&asl=135&tz=Europe%2FZagreb&dpi=72&apikey=jhMJTOUVRNvs25m4&lang=en&location_name=Zagreb&sig=9f25f63e492378fa1a97510d2a290acd" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteoblue.com/en/weather/week/split_croatia_3190261" target="_blank" rel="nofollow">meteoblue | Prognoza | Split</a>
+							<div class="radartitle">
+								<a href="https://www.meteoblue.com/en/weather/week/split_croatia_3190261" target="_blank" rel="nofollow">meteoblue | Prognoza | Split</a>
+							</div>
 							<div class="placeholder" style="aspect-ratio: 1152 / 963;">
 								<img src="https://my.meteoblue.com/images/meteogram?temperature_units=C&windspeed_units=kmh&precipitation_units=mm&darkmode=true&iso2=hr&lat=43.5089&lon=16.4391&asl=12&tz=Europe%2FZagreb&dpi=72&apikey=jhMJTOUVRNvs25m4&lang=en&location_name=Split&sig=52d3eea0042ccfccd932445f3ff1a158" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteoblue.com/en/weather/week/rijeka_croatia_3191648" target="_blank" rel="nofollow">meteoblue | Prognoza | Rijeka</a>
+							<div class="radartitle">
+								<a href="https://www.meteoblue.com/en/weather/week/rijeka_croatia_3191648" target="_blank" rel="nofollow">meteoblue | Prognoza | Rijeka</a>
+							</div>
 							<div class="placeholder" style="aspect-ratio: 1152 / 963;">
 								<img src="https://my.meteoblue.com/images/meteogram?temperature_units=C&windspeed_units=kmh&precipitation_units=mm&darkmode=true&iso2=hr&lat=45.3267&lon=14.4424&asl=12&tz=Europe%2FZagreb&dpi=72&apikey=jhMJTOUVRNvs25m4&lang=en&location_name=Rijeka&sig=67a56b4147ade3e713667e2451e5a94a" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteoblue.com/en/weather/week/osijek_croatia_3193935" target="_blank" rel="nofollow">meteoblue | Prognoza | Osijek</a>
+							<div class="radartitle">
+								<a href="https://www.meteoblue.com/en/weather/week/osijek_croatia_3193935" target="_blank" rel="nofollow">meteoblue | Prognoza | Osijek</a>
+							</div>
 							<div class="placeholder" style="aspect-ratio: 1152 / 963;">
 								<img src="https://my.meteoblue.com/images/meteogram?temperature_units=C&windspeed_units=kmh&precipitation_units=mm&darkmode=true&iso2=hr&lat=45.5511&lon=18.6939&asl=87&tz=Europe%2FZagreb&dpi=72&apikey=jhMJTOUVRNvs25m4&lang=en&location_name=Osijek&sig=9c848ca560bfeec99a8f8d812b50e4c8" />
 							</div>

--- a/src/index.html
+++ b/src/index.html
@@ -54,13 +54,15 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>Radar | Hrvatska :</b>
+					<br /><b>>></b>
 					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 					<!--<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24.com</a>-->
 					<!--<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Meteoradar</a>-->
 					<!--<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">I'm Weather</a>-->
 					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>
+					<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					<!--<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Weather&Radar</a>-->
 					<!--<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>-->
 				</td>
 			</tr>
@@ -112,6 +114,15 @@
 						<span class="indicator active"></span>
 						<span class="indicator"></span>
 					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="left">
+					<br /><b>>></b>
+					<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 				</td>
 			</tr>
 			<tr class="sp"></tr>
@@ -242,16 +253,16 @@
 			<tr class="sp"></tr>
 
 			<!--
-			<tr>
-				<td align="center">
-					<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
-					<div class="placeholder" style="max-width: 800px; aspect-ratio: 1;">
-						<img src="https://www.estofex.org/forecasts/tempmap/.png" />
-					</div>
-				</td>
-			</tr>
-			<tr class="sp"></tr>
-			-->
+	<tr>
+		<td align="center">
+			<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+			<div class="placeholder" style="max-width: 800px; aspect-ratio: 1;">
+				<img src="https://www.estofex.org/forecasts/tempmap/.png" />
+			</div>
+		</td>
+	</tr>
+	<tr class="sp"></tr>
+	-->
 
 			<tr>
 				<td align="center">

--- a/src/index.html
+++ b/src/index.html
@@ -54,7 +54,8 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>>></b>
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 					<!--<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24.com</a>-->
 					<!--<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Meteoradar</a>-->
@@ -91,6 +92,15 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="left">
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+					<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+				</td>
+			</tr>
 			<tr class="sp"></tr>
 
 			<tr>
@@ -118,7 +128,8 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>>></b>
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 					<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 					<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
@@ -148,6 +159,15 @@
 						<span class="indicator active"></span>
 						<span class="indicator"></span>
 					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="left">
+					<br /><b>></b>
+					<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+					<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
 				</td>
 			</tr>
 			<tr class="sp"></tr>

--- a/src/index.html
+++ b/src/index.html
@@ -53,18 +53,16 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left" style="font-size: 12px; padding: 5px 0px; background-color: #234e6d">
-					<b>></b>
-					<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<!--<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24.com</a>-->
-					<!--<a href="https://www.meteoradar.co.uk/en-gb/country/hr" target="_blank" rel="nofollow">Meteoradar</a>-->
-					<!--<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6.00" target="_blank" rel="nofollow">I'm Weather</a>-->
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-					<!--<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>-->
+				<td align="left">
+					<div class="links-bottom">
+						<b>></b>
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -93,12 +91,14 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left" style="font-size: 12px">
-					<b>></b>
-					<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+				<td align="left">
+					<div class="links-bottom">
+						<b>></b>
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -128,13 +128,15 @@
 			</tr>
 			<tr>
 				<td align="left">
-					<br /><b>></b>
-					<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-					<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					<div class="links-bottom">
+						<b>></b>
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -163,12 +165,14 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left" style="font-size: 12px">
-					<b>></b>
-					<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-					<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-					<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-					<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+				<td align="left">
+					<div class="links-bottom">
+						<b>></b>
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+					</div>
 				</td>
 			</tr>
 			<tr class="sp30"></tr>
@@ -235,8 +239,8 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left" style="font-size: 12px">
-					<div style="max-width: 768px; text-align:left">
+				<td align="left">
+					<div class="links-bottom" style="max-width: 768px">
 						<b>></b>
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>

--- a/src/index.html
+++ b/src/index.html
@@ -132,7 +132,7 @@
 			<tr>
 				<td align="center">
 					<div class="radartitle">
-						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,8" target="_blank" rel="nofollow">Windy</a>
+						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a class="right" id="resetWindyFrame" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">

--- a/src/index.html
+++ b/src/index.html
@@ -398,7 +398,7 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 800px">
 						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
+						· <a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -61,14 +61,14 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -103,11 +103,11 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -142,13 +142,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -183,12 +183,12 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -216,13 +216,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -253,14 +253,14 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 720px">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
+						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -298,12 +298,12 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 768px">
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
 				</td>
 			</tr>
@@ -331,8 +331,8 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung</a>
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
-						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -367,7 +367,7 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 900px">
 						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
+						· <a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>
@@ -418,13 +418,13 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -484,12 +484,12 @@
 				<td align="center">
 					<div class="links-bottom" style="max-width: 768px">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
-						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -612,11 +612,11 @@
 				<td align="center">
 					<div class="links-bottom">
 						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a>
-						<a href="https://vrijeme-i-promet.hrt.hr/vrijeme/" target="_blank" rel="nofollow">HRT Vrijeme</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
-						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
-						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
-						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://vrijeme-i-promet.hrt.hr/vrijeme/" target="_blank" rel="nofollow">HRT Vrijeme</a>
+						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						· <a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
+						· <a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
+						· <a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -290,7 +290,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
+					<div class="radartitle" style="max-width: 900px;">
+						<a href="https://www.stormforecast.eu" target="_blank" rel="nofollow">ESSL | Prognoza nevremena</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="16" data-current-slide="2" style="max-width: 900px; aspect-ratio: 900 / 600;">
 						<div class="slide fade">
 							<img data-src="https://meteo-data.jurakovic.workers.dev/essl/img1.png" class="lazy" />
@@ -315,7 +317,9 @@
 
 			<tr>
 				<td align="center">
-					<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX | Prognoza nevremena</a>
+					<div class="radartitle" style="max-width: 800px;">
+						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX | Prognoza nevremena</a>
+					</div>
 					<div class="slideshow placeholder" data-slideshow-id="18" data-current-slide="1" style="max-width: 800px; aspect-ratio: 1;">
 						<div class="slide fade active">
 							<img src="https://meteo-data.jurakovic.workers.dev/estofex/img1.png" />
@@ -350,26 +354,34 @@
 				<td align="center">
 					<div class="slideshow" data-slideshow-id="5" data-current-slide="1" style="max-width: 768px;">
 						<div class="slide fade active">
-							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img src="https://modeles20.meteociel.fr/satellite/animsatirmtgeu.gif" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=infrarouge-noir-et-blanc-hd-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img data-src="https://modeles20.meteociel.fr/satellite/latestsatirmtgeu.png" class="lazy" />
 							</div>
 						</div>
 						<!--
 						<div class="slide fade">
-							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-sandwich-visible-infrarouge-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=animation-sandwich-visible-infrarouge-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img data-src="https://modeles20.meteociel.fr/satellite/animsatsandvisirmtgeu.gif" class="lazy" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=sandwich-visible-infrarouge-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							<div class="radartitle">
+								<a href="https://www.meteociel.fr/observations-meteo/satellite.php?mode=sandwich-visible-infrarouge-mtg" target="_blank" rel="nofollow">Meteociel.fr | Satelit</a>
+							</div>
 							<div class="placeholder" style="max-width: 768px; aspect-ratio: 1;">
 								<img data-src="https://modeles20.meteociel.fr/satellite/latestsatsandvisirmtgeu.png" class="lazy" />
 							</div>
@@ -394,25 +406,33 @@
 				<td align="center">
 					<div class="slideshow" data-slideshow-id="17" data-current-slide="1" data-dynamic-width style="max-width: 760px;">
 						<div class="slide fade active">
-							<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/aktualni-situace/aktualni-stav-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 492;">
 								<img src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/analyza.gif" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 435; ">
 								<img data-src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/preba/preba36.gif" class="lazy" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 435; ">
 								<img data-src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/preba/preba60.gif" class="lazy" />
 							</div>
 						</div>
 						<div class="slide fade">
-							<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							<div class="radartitle">
+								<a href="https://intranet.chmi.cz/predpovedi/predpovedi-pocasi/evropa/synopticka-situace" target="_blank" rel="nofollow">ČHMÚ | Sinoptička karta</a>
+							</div>
 							<div class="placeholder" style="max-width: 760px; aspect-ratio: 760 / 435; ">
 								<img data-src="https://intranet.chmi.cz/files/portal/docs/meteo/om/evropa/preba/preba84.gif" class="lazy" />
 							</div>

--- a/src/index.html
+++ b/src/index.html
@@ -65,7 +65,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -146,7 +146,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -219,7 +219,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -257,7 +257,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
@@ -301,7 +301,7 @@
 						<a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
@@ -422,7 +422,7 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,10 @@
 				<td align="center">
 					<div class="buttons">
 						<a href="/extras/index.html" style="text-decoration: none"><div class="btn">Više</div></a>
-						<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+						<div class="links-btn">
+							<button type="button" class="btn" onclick="scrollToElement('links')">Linkovi</button>
+							<input type="checkbox" class="links-toggle" onchange="toggleLinksBottom(this)" title="Prikaži linkove ispod karata" />
+						</div>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -313,7 +313,7 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
-						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung | Munje</a>
+						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
@@ -330,8 +330,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung</a>
-						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung.org</a>
+						· <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
 						· <a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
@@ -66,6 +66,9 @@
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép*</a>
 					</div>
 				</td>
 			</tr>
@@ -97,12 +100,14 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
 					</div>
 				</td>
 			</tr>
@@ -134,14 +139,16 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,17.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
 					</div>
 				</td>
 			</tr>
@@ -173,12 +180,15 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="left">
+				<td align="center">
 					<div class="links-bottom">
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
 					</div>
 				</td>
 			</tr>
@@ -202,12 +212,24 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth*</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue*</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky*</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R*</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
 					<div class="radartitle" style="max-width: 720px;">
-						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | kompozit</a>
+						<a href="https://meteo.hr/podaci.php?section=podaci_mjerenja&param=radari&el=kompozit&acto=anim" target="_blank" rel="nofollow">DHMZ | Radar | Hrvatska</a>
 					</div>
 					<div class="slideshow placeholder" data-slideshow-id="7" data-current-slide="1" style="max-width: 720px; aspect-ratio: 720 / 751;">
 						<div class="slide fade active">
@@ -222,6 +244,14 @@
 					<div class="indicators-container" data-slideshow-id="7" style="max-width: 720px; grid-template-columns: repeat(2, 1fr);">
 						<span class="indicator active"></span>
 						<span class="indicator"></span>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 720px">
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy*</a>
 					</div>
 				</td>
 			</tr>
@@ -263,6 +293,8 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar*</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak*</a>
 					</div>
 				</td>
 			</tr>
@@ -272,7 +304,7 @@
 				<td align="center">
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
-						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org</a> // <a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps.org</a>
+						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung | Munje</a>
 						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
 					</div>
 					<div class="if1 placeholder">
@@ -283,6 +315,14 @@
 						<div class="overlay" id="overlayBlitzortungFrame" data-frame-id="blitzortung">
 							<span class="hint">Dvostruki klik za pristup interaktivnoj karti</span>
 						</div>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps*</a>
+						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin*</a>
 					</div>
 				</td>
 			</tr>
@@ -313,6 +353,14 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 900px">
+						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX*</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -336,6 +384,14 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 800px">
+						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL*</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -345,6 +401,20 @@
 					</div>
 					<div class="if2 placeholder">
 						<iframe loading="lazy" src="https://cdn.fmi.fi/demos/eumetnet-web-site-radar-animator/" frameborder="0" scrolling="no"></iframe>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
 					</div>
 				</td>
 			</tr>
@@ -400,6 +470,19 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 768px">
+						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
+					</div>
+				</td>
+			</tr>
 			<tr class="sp20"></tr>
 
 			<tr>
@@ -445,6 +528,13 @@
 						<span class="indicator"></span>
 						<span class="indicator"></span>
 						<span class="indicator"></span>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom" style="max-width: 760px">
+						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ*</a>
 					</div>
 				</td>
 			</tr>
@@ -505,6 +595,16 @@
 						<span class="indicator"></span>
 						<span class="indicator"></span>
 						<span class="indicator"></span>
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td align="center">
+					<div class="links-bottom">
+						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ*</a>
+						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin*</a>
+						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no*</a>
+						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale*</a>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -616,7 +616,7 @@
 						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 						· <a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
 						· <a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
-						· <a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
+						· <a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ecm&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -526,7 +526,7 @@
 		<!-- cnt -->
 	</div>
 	<footer>
-		<a onclick="scrollToTop()" style="cursor: pointer"><u>Povratak na vrh</u></a>
+		<a onclick="scrollToTop()" style="cursor: pointer">Povratak na vrh</a>
 		·
 		<a href="/extras/index.html">Više</a>
 		|

--- a/src/index.html
+++ b/src/index.html
@@ -69,7 +69,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -106,7 +106,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -145,7 +145,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -182,7 +182,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -202,7 +202,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -225,7 +225,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -266,7 +266,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp30"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -286,7 +286,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -313,7 +313,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -336,7 +336,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -348,7 +348,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -400,7 +400,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -448,7 +448,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">
@@ -460,7 +460,7 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="sp"></tr>
+			<tr class="sp20"></tr>
 
 			<tr>
 				<td align="center">

--- a/src/index.html
+++ b/src/index.html
@@ -66,9 +66,9 @@
 						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
-						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép*</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -106,8 +106,8 @@
 						<a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -147,8 +147,8 @@
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -186,9 +186,9 @@
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -215,12 +215,14 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth*</a>
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
-						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue*</a>
-						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky*</a>
-						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R*</a>
-						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -250,8 +252,15 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 720px">
-						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer*</a>
-						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy*</a>
+						<a href="https://www.windy.com/-Weather-radar-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
+						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
+						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
+						<a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
+						<a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
+						<a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.idokep.eu/adria" target="_blank" rel="nofollow">Időkép</a>
 					</div>
 				</td>
 			</tr>
@@ -293,8 +302,8 @@
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar*</a>
-						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak*</a>
+						<a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
 					</div>
 				</td>
 			</tr>
@@ -321,8 +330,9 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps*</a>
-						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin*</a>
+						<a href="https://www.blitzortung.org/en/historical_maps.php?map=10" target="_blank" rel="nofollow">Blitzortung</a>
+						<a href="https://www.lightningmaps.org/?lang=en#m=sen;t=3;s=200;o=0;b=0.00;ts=0;z=7;y=44.5;x=16.5;d=4;dl=6;dc=0;" target="_blank" rel="nofollow">LightningMaps</a>
+						<a href="https://www.neverin.hr/munje/" target="_blank" rel="nofollow">Neverin</a>
 					</div>
 				</td>
 			</tr>
@@ -356,8 +366,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 900px">
-						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX*</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+						<a href="https://www.estofex.org" target="_blank" rel="nofollow">ESTOFEX</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>
@@ -387,8 +397,8 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 800px">
-						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL*</a>
-						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD*</a>
+						<a href="https://weather.essl.org/storm/" target="_blank" rel="nofollow">ESSL</a>
+						<a href="https://www.eswd.eu" target="_blank" rel="nofollow">ESWD</a>
 					</div>
 				</td>
 			</tr>
@@ -413,8 +423,8 @@
 						<a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
 						<a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">W&R</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
 				</td>
 			</tr>
@@ -477,9 +487,9 @@
 						<a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						<a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						<a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
-						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24*</a>
-						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather*</a>
-						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale*</a>
+						<a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
+						<a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
+						<a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>
@@ -534,7 +544,7 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom" style="max-width: 760px">
-						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ*</a>
+						<a href="https://meteo.hr/prognoze.php?section=prognoze_model&param=web_fronte_sutra12" target="_blank" rel="nofollow">DHMZ</a>
 					</div>
 				</td>
 			</tr>
@@ -601,10 +611,12 @@
 			<tr>
 				<td align="center">
 					<div class="links-bottom">
-						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ*</a>
-						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin*</a>
-						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no*</a>
-						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale*</a>
+						<a href="https://meteo.hr" target="_blank" rel="nofollow">DHMZ</a>
+						<a href="https://vrijeme-i-promet.hrt.hr/vrijeme/" target="_blank" rel="nofollow">HRT Vrijeme</a>
+						<a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
+						<a href="https://www.neverin.hr/prognoza/zagreb/" target="_blank" rel="nofollow">Neverin</a>
+						<a href="https://www.yr.no/en/details/table/2-3186886/Croatia/City%20of%20Zagreb/Zagreb" target="_blank" rel="nofollow">Yr.no</a>
+						<a href="https://www.wetterzentrale.de/en/show_diagrams.php?geoid=54032&model=ico&var=93&run=6&lid=OP&bw=1" target="_blank" rel="nofollow">Wetterzentrale</a>
 					</div>
 				</td>
 			</tr>

--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -108,7 +108,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
 					</div>
@@ -148,7 +148,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
@@ -188,7 +188,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>
@@ -221,7 +221,7 @@
 						<a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -259,7 +259,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=44.5,16.5,7z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/country/hr/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=44.5000&lng=16.5000&z=6" target="_blank" rel="nofollow">I'm Weather</a>
@@ -303,7 +303,7 @@
 						<a href="https://www.windy.com/-Temperature-temp?temp,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/temperature/#view=44.5,16.5,7z/model=icon" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=temperature~daily-max~auto~2%20m%20above%20gnd~none&coords=6/44.5/16.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=44.49;16.50;6&l=temperature-2m&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=tr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.meteoradar.co.uk/en-gb/country/hr/maps/temperature" target="_blank" rel="nofollow">Meteoradar</a>
 						· <a href="https://pljusak.com/karta.php" target="_blank" rel="nofollow">Pljusak</a>
@@ -424,7 +424,7 @@
 						· <a href="https://zoom.earth/maps/radar/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=radar~radarMapEU~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
 						· <a href="https://www.rainviewer.com/map.html?loc=47.5,17.5,4&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=47.5,15.5&zoom=5&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd#selectedLayer=euRadarSat" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&run=&member=&element=radsat&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
@@ -489,7 +489,7 @@
 						<a href="https://www.windy.com/-Satellite-satellite?satellite,47.5,17.5,5" target="_blank" rel="nofollow">Windy</a>
 						· <a href="https://zoom.earth/maps/satellite/#view=47.5,17.5,5z" target="_blank" rel="nofollow">Zoom Earth</a>
 						· <a href="https://www.meteoblue.com/en/weather/maps/croatia_croatia_3202326#map=satellite~radar~none~none~none&coords=4/47.5/17.5" target="_blank" rel="nofollow">meteoblue</a>
-						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventussky</a>
+						· <a href="https://www.ventusky.com/?p=47.5;17.5;4&l=satellite&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						· <a href="https://www.sat24.com/en-gb/continent/eu/hd" target="_blank" rel="nofollow">Sat24</a>
 						· <a href="https://imweather.com/?model=nowcast&element=satellite&run=&member=&level=&lat=47.5000&lng=17.5000&z=4.2" target="_blank" rel="nofollow">I'm Weather</a>
 						· <a href="https://www.wetterzentrale.de/en/reanalysis.php?map=1&model=sat&var=404&nmaps=32" target="_blank" rel="nofollow">Wetterzentrale</a>


### PR DESCRIPTION
- **Inline links below each radar/satellite image** — added a row of quick links (Windy, Zoom Earth, meteoblue, Rain Viewer, Ventussky, Vrijeme&Radar, Sat24, I'm Weather, Időkép) under each map on both the main and extras pages, with region-specific coordinates per image.
- **Horizontally scrollable link bars** — link rows scroll on overflow with a hidden scrollbar and scroll-aware fade hints (left/right shadow indicators) that update on scroll and resize.
- **"Linkovi" toggle** — new checkbox next to the Linkovi button that shows/hides the inline link rows, with the preference persisted in `localStorage`.
- **Links component refresh** — added Ventusky and Rain Viewer sources, renamed "Weather&Radar" → "Vrijeme&Radar", switched Wetterzentrale temperature/forecast model from ICON to ECMWF, fixed a broken `target` attribute and the Blitz link, cleaned up URL params, and underlined section headers.
- **Styling/layout tweaks** — new `radartitle` wrappers, `sp20` spacers (collapse to `sp` height on mobile), refined slide indicator visibility.
