### PR TITLE
Add fullscreen toggle for embedded radar/satellite maps

### DIFF
--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -42,36 +42,37 @@
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
 		padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
-		align-items:center;justify-content:center;position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;background-color:#2b5797;color:
-		#fff;cursor:pointer;transform:translateZ(0)}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;background-color:#3a3f4a
-		;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
-		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;transform:translateZ(0)}.fs-exit-bar .fs-bar-btn{flex:1;display:flex;
+		align-items:center;justify-content:center;background-color:#2b5797;color:#fff;cursor:pointer}.fs-exit-bar .fs-bar-btn+.fs-bar-btn{
+		border-left:1px solid #1f3d6b}.fs-exit-bar .fs-exit{flex:2}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;
+		background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
+		scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
+		content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
+		pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:
+		linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -119,26 +120,28 @@
 		;o=o.replace(e.getAttribute(n),e.getAttribute(s))}e.src=o}function switchIframeZoom(e,t){
 		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
 		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getResetButtonFromFrameId(e)
-		;"[R]"===s.textContent&&(s.style.display="none")}function toggleFullscreen(e,t){dlog(`toggleFullscreen: ${e}`)
-		;const o=document.getElementById(e).parentElement;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{
-		const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
-		resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
-		o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
-		s&&(s.style.display="none");const r=document.createElement("div");r.className="fs-exit-bar",r.textContent="✕ Zatvori cijeli zaslon",
-		r.addEventListener("click",()=>exitFullscreen(o)),document.body.appendChild(r),o._fsExitBar=r}}function exitFullscreen(e){
+		;"[R]"!==s.textContent||n.parentElement.classList.contains("fullscreen")||(s.style.display="none")}function toggleFullscreen(e,t){
+		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
+		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
+		;if(o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
+		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s),
+		window.innerWidth<=800){const t=document.createElement("div");t.className="fs-exit-bar";const n=document.createElement("div")
+		;n.className="fs-bar-btn fs-reset",n.textContent="Reset",n.addEventListener("click",()=>resetIframePosition(e))
+		;const s=document.createElement("div");s.className="fs-bar-btn fs-exit",s.textContent="Zatvori",
+		s.addEventListener("click",()=>exitFullscreen(o)),t.append(s,n),document.body.appendChild(t),o._fsExitBar=t}}}function exitFullscreen(e){
 		e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
 		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
-		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
-		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
-		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
-		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
-		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
-		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=!1===e._fsOverlayVisible
+		;delete e._fsOverlayVisible;const s=e.querySelector(".overlay");s&&(n?s.style.display="none":s.removeAttribute("style"))
+		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(r.style.removeProperty("display"),
+		n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
+		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
+		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
+		;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
+		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
+		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
+		e.addEventListener("touchend",e=>{if(!n)return
 		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
@@ -151,10 +154,14 @@
 		dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 		e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
 		dlog(`Resetting iframe: ${e}`),setIframeSrc(document.getElementById(e));const t=getResetButtonFromFrameId(e);t.style.display="none",
-		setResetButtonToExit(t)}function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}
-		function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}
-		function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function GetLastInit(){
-		let e=new Date;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
+		setResetButtonToExit(t)}function resetIframePosition(e){dlog(`resetIframePosition: ${e}`),setIframeSrc(document.getElementById(e))}
+		function setResetButtonToFullscreenReset(e){dlog(`setResetButtonToFullscreenReset: ${e.id}`);const t=e.cloneNode(!0)
+		;e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{e.stopPropagation(),resetIframePosition(getFrameIdFromResetButtonId(t.id))}),
+		t.textContent="[R]",t.style.removeProperty("display")}function getResetButtonFromFrameId(e){
+		return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
+		return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
+		return document.getElementById(e).getAttribute("data-frame-id")}function GetLastInit(){let e=new Date
+		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -40,11 +40,11 @@
 		:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
-		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
-		padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
-		position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;transform:translateZ(0)}.fs-exit-bar .fs-bar-btn{flex:1;display:flex;
-		align-items:center;justify-content:center;background-color:#2b5797;color:#fff;cursor:pointer}.fs-exit-bar .fs-bar-btn+.fs-bar-btn{
-		border-left:1px solid #1f3d6b}.fs-exit-bar .fs-exit{flex:2}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;
+		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;display:flex;align-items:center;justify-content:center}
+		.radartitle.fullscreen .center{transform:none;left:auto}.radartitle.fullscreen .left,.radartitle.fullscreen .right{top:50%;transform:
+		translateY(-50%)}.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}.if1.fullscreen{position:
+		fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}@media (max-width:800px){
+		.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}}.links-bottom{display:none;text-align:left;
 		background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
 		scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
 		content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
@@ -102,11 +102,11 @@
 		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,s=0,r=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
 		o=e.touches[0].clientY),r=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?r=!1:(n=e.touches[0].clientX,s=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,i=s-o
-		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,l=s-o
+		;Math.abs(r)>Math.abs(l)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseup",l=>{if(r){n=l.clientX,s=l.clientY;const i=n-t,a=s-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
 		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -123,18 +123,14 @@
 		;"[R]"!==s.textContent||n.parentElement.classList.contains("fullscreen")||(s.style.display="none")}function toggleFullscreen(e,t){
 		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
-		;if(o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s),
-		window.innerWidth<=800){const t=document.createElement("div");t.className="fs-exit-bar";const n=document.createElement("div")
-		;n.className="fs-bar-btn fs-reset",n.textContent="Reset",n.addEventListener("click",()=>resetIframePosition(e))
-		;const s=document.createElement("div");s.className="fs-bar-btn fs-exit",s.textContent="Zatvori",
-		s.addEventListener("click",()=>exitFullscreen(o)),t.append(s,n),document.body.appendChild(t),o._fsExitBar=t}}}function exitFullscreen(e){
-		e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
-		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
-		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=!1===e._fsOverlayVisible
-		;delete e._fsOverlayVisible;const s=e.querySelector(".overlay");s&&(n?s.style.display="none":s.removeAttribute("style"))
-		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(r.style.removeProperty("display"),
-		n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
+		;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
+		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+		function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
+		;const o=t.querySelector(".fs-btn")
+		;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")
+		;const n=!1===e._fsOverlayVisible;delete e._fsOverlayVisible;const s=e.querySelector(".overlay")
+		;s&&(n?s.style.display="none":s.removeAttribute("style"));const r=getResetButtonFromFrameId(e.querySelector("iframe").id)
+		;r&&(r.style.removeProperty("display"),n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
 		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
@@ -142,7 +138,7 @@
 		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
 		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
 		e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,l=Math.abs(t-r),i=Math.abs(o-s);l<10&&i<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -128,13 +128,17 @@
 		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
 		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
 		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
-		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
-		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
+		1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
+		const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
+		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function hideOverlayOnDoubleTap(){
+		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
+		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
+		;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
+		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
+		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
+		e.addEventListener("touchend",e=>{if(!n)return
 		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
@@ -156,7 +160,7 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
 		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
 		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -42,9 +42,9 @@
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;display:flex;align-items:center;justify-content:center}
 		.radartitle.fullscreen .center{transform:none;left:auto}.radartitle.fullscreen .left,.radartitle.fullscreen .right{top:50%;transform:
-		translateY(-50%)}.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}.if1.fullscreen{position:
-		fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}@media (max-width:800px){
-		.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}}.links-bottom{display:none;text-align:left;
+		translateY(-50%)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
+		@media (max-width:800px){.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}
+		.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}}.links-bottom{display:none;text-align:left;
 		background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
 		scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
 		content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
@@ -124,7 +124,7 @@
 		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
 		;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+		document.body.classList.add("fs-lock"),t.textContent="[□]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
 		function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
 		;const o=t.querySelector(".fs-btn")
 		;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")
@@ -203,8 +203,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventusky', this)">[HR]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('ventusky', this)">[ ]</a>
 							<a id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('ventusky', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">
@@ -240,8 +240,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('rainViewer', this)">[HR]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('rainViewer', this)">[ ]</a>
 							<a id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('rainViewer', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">
@@ -277,8 +277,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('weatherAndRadar', this)">[ ]</a>
 							<a id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('weatherAndRadar', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -41,35 +41,36 @@
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%}body.fs-lock{
-		overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap
-		;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none
-		}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%;pointer-events:none}
+		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
+		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
+		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
+		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
+		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
+		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
+		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
+		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
+		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
+		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
+		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
+		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -103,7 +103,7 @@
 		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const a=n-t,l=s-o;Math.abs(a)>Math.abs(l)&&handleSwipe(e,t,n),r=!1}}),
 		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -131,7 +131,15 @@
 		function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
 		1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
 		const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
-		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function hideOverlayOnDoubleTap(){
+		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function addTapDebugReadout(){
+		if(!isDebugEnabled)return;const e=document.createElement("div");e.id="tapDebug",
+		e.style.cssText="position:fixed;left:0;right:0;bottom:0;z-index:2147483647;pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all",
+		e.textContent="tap debug ready",document.body.appendChild(e);const t={pointerdown:0,touchstart:0,touchend:0,click:0},o=(o,n)=>{t[o]++
+		;const s=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0]||n,r=Math.round(s&&s.clientX||0),i=Math.round(s&&s.clientY||0)
+		;e.textContent=`pd:${t.pointerdown} ts:${t.touchstart} te:${t.touchend} ck:${t.click}\nlast: ${o} @${r},${i}  fs:${!!document.querySelector(".if1.fullscreen")}\ntarget: ${(e=>{
+		if(!(e instanceof Element))return String(e);let t=e.tagName.toLowerCase();return e.id&&(t+="#"+e.id),
+		"string"==typeof e.className&&e.className.trim()&&(t+="."+e.className.trim().replace(/\s+/g,".")),t})(n.target)}`}
+		;["pointerdown","touchstart","touchend","click"].forEach(e=>document.addEventListener(e,t=>o(e,t),!0))}function hideOverlayOnDoubleTap(){
 		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
@@ -139,7 +147,7 @@
 		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
 		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
 		e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(o-s);i<10&&a<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -160,9 +168,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
-		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
-		updateHintText(),updateLinksScrollShadows()},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),addTapDebugReadout(),updateHintText(),initLinksBottom(),
+		addLinksScrollShadows()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{
+		updateIframeSrc(),updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
 	
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -39,36 +39,35 @@
 		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
 		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
 		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{
-		transform:none;width:100%;height:100%}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;
-		box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
-		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
+		.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto
+		;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
+		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -40,20 +40,21 @@
 		:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
-		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%;pointer-events:none}
-		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
-		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
-		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
-		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
-		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
-		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
-		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
-		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
-		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
-		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
-		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
+		padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
+		align-items:center;justify-content:center;position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;background-color:#2b5797;color:
+		#fff;cursor:pointer;transform:translateZ(0)}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;background-color:#3a3f4a
+		;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
 		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
 		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
 		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
@@ -104,7 +105,7 @@
 		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const a=n-t,l=s-o;Math.abs(a)>Math.abs(l)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
 		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -123,32 +124,22 @@
 		const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
 		resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
 		o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
-		s&&(s.style.display="none")}}function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling
+		s&&(s.style.display="none");const r=document.createElement("div");r.className="fs-exit-bar",r.textContent="✕ Zatvori cijeli zaslon",
+		r.addEventListener("click",()=>exitFullscreen(o)),document.body.appendChild(r),o._fsExitBar=r}}function exitFullscreen(e){
+		e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
 		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
 		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
 		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
 		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
 		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-		function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
-		1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
-		const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
-		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function addTapDebugReadout(){
-		if(!isDebugEnabled)return;const e=document.createElement("div");e.id="tapDebug",
-		e.style.cssText="position:fixed;left:0;right:0;bottom:0;z-index:2147483647;pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all",
-		e.textContent="tap debug ready",document.body.appendChild(e);const t={pointerdown:0,touchstart:0,touchend:0,click:0},o=(o,n)=>{t[o]++
-		;const s=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0]||n,r=Math.round(s&&s.clientX||0),i=Math.round(s&&s.clientY||0)
-		;e.textContent=`pd:${t.pointerdown} ts:${t.touchstart} te:${t.touchend} ck:${t.click}\nlast: ${o} @${r},${i}  fs:${!!document.querySelector(".if1.fullscreen")}\ntarget: ${(e=>{
-		if(!(e instanceof Element))return String(e);let t=e.tagName.toLowerCase();return e.id&&(t+="#"+e.id),
-		"string"==typeof e.className&&e.className.trim()&&(t+="."+e.className.trim().replace(/\s+/g,".")),t})(n.target)}`}
-		;["pointerdown","touchstart","touchend","click"].forEach(e=>document.addEventListener(e,t=>o(e,t),!0))}function hideOverlayOnDoubleTap(){
-		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
-		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
-		;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
-		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
-		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
-		e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(o-s);i<10&&a<10&&(n.style.opacity="0.6",
+		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
+		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
+		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
+		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -169,9 +160,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),addTapDebugReadout(),updateHintText(),initLinksBottom(),
-		addLinksScrollShadows()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{
-		updateIframeSrc(),updateHintText(),updateLinksScrollShadows()},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
+		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
 	
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -41,35 +41,35 @@
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-		left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:
-		#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
-		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%}body.fs-lock{
+		overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap
+		;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none
+		}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -30,42 +30,45 @@
 		background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
 		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
 		position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
-		text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;
-		padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}
-		.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
-		background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
-		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
-		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
-		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-		{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
-		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
-		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		text-decoration:none;cursor:pointer}.radartitle .right-cluster{display:inline-flex;gap:8px}.radartitle .right-cluster a{text-decoration:none
+		;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}
+		@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;
+		transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}
+		@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:
+		hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:
+		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
+		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
+		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
+		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{
+		transform:none;width:100%;height:100%}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;
+		box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -81,9 +84,9 @@
 		document.body.classList.toggle("show-links-bottom",e.checked))}function plusSlides(e,t){
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
-		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
-		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),s=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
+		;let r=t;r>n.length&&(r=1),r<1&&(r=n.length),e.setAttribute("data-current-slide",r),n.forEach(e=>e.classList.remove("active")),
+		n[r-1].classList.add("active"),s.forEach(e=>e.classList.remove("active")),s[r-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -92,15 +95,15 @@
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,s=0,r=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
-		o=e.touches[0].clientY),s=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?s=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(r-o)&&(s=!0))}),e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o
-		;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		o=e.touches[0].clientY),r=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?r=!1:(n=e.touches[0].clientX,s=e.touches[0].clientY,
+		Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,i=s-o
+		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
-		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
+		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
@@ -109,18 +112,29 @@
 		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
 		;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
-		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
-		;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
+		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",s="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
+		;o=o.replace(e.getAttribute(n),e.getAttribute(s))}e.src=o}function switchIframeZoom(e,t){
 		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
-		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getResetButtonFromFrameId(e)
-		;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
-		let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-		setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),s=r-t;if(s>0&&s<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
-		;const n=e.querySelector(".hint");let r=0,s=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(s=e.touches[0].clientX,
-		r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-s),a=Math.abs(o-r);i<10&&a<10&&(n.style.opacity="0.6",
+		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getResetButtonFromFrameId(e)
+		;"[R]"===s.textContent&&(s.style.display="none")}function toggleFullscreen(e,t){dlog(`toggleFullscreen: ${e}`)
+		;const o=document.getElementById(e).parentElement;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{
+		const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
+		resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
+		o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
+		s&&(s.style.display="none")}}function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling
+		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
+		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
+		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
+		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
+		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
+		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
+		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
+		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
+		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -180,7 +194,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventusky', this)">[HR]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
-						<a class="right" id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('ventusky', this)">[ ]</a>
+							<a id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="ventusky" class="scaled-iframe" loading="eager" frameborder="0"
@@ -214,7 +231,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('rainViewer', this)">[HR]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('rainViewer', this)">[ ]</a>
+							<a id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" frameborder="0"
@@ -248,7 +268,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('weatherAndRadar', this)">[ ]</a>
+							<a id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-hr-desktop="&zoom=7.2" data-zoom-hr-mobile="&zoom=6.8" data-zoom-eu-desktop="&zoom=5.0" data-zoom-eu-mobile="&zoom=4.0"

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -124,7 +124,7 @@
 		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
 		;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-		document.body.classList.add("fs-lock"),t.textContent="[□]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
 		function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
 		;const o=t.querySelector(".fs-btn")
 		;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -39,35 +39,36 @@
 		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
 		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
 		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
-		.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto
-		;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
-		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}
+		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
+		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
+		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
+		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
+		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
+		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
+		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
+		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
+		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
+		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
+		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
+		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/extras/index.html
+++ b/docs/extras/index.html
@@ -31,27 +31,28 @@
 		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
 		position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
 		text-decoration:none;cursor:pointer}.radartitle .right-cluster{display:inline-flex;gap:8px}.radartitle .right-cluster a{text-decoration:none
-		;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}
-		@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;
-		transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}
-		@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:
-		hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:
-		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
-		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
-		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-		z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}
-		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
-		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
-		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
-		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
-		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
-		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
-		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
-		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
-		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
-		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
-		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		;cursor:pointer;position:relative}.radartitle .right-cluster a::before,.radartitle .zoom-btn::before{content:'';position:absolute;top:50%;
+		left:50%;transform:translate(-50%,-50%);width:26px;height:26px}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;
+		width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:
+		100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:
+		translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{
+		opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top
+		:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
+		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
+		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
+		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
+		left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:
+		#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
 		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
 		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
 		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,9 +42,9 @@
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;display:flex;align-items:center;justify-content:center}
 		.radartitle.fullscreen .center{transform:none;left:auto}.radartitle.fullscreen .left,.radartitle.fullscreen .right{top:50%;transform:
-		translateY(-50%)}.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}.if1.fullscreen{position:
-		fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}@media (max-width:800px){
-		.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}}.links-bottom{display:none;text-align:left;
+		translateY(-50%)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
+		@media (max-width:800px){.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}
+		.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}}.links-bottom{display:none;text-align:left;
 		background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
 		scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
 		content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
@@ -124,7 +124,7 @@
 		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
 		;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+		document.body.classList.add("fs-lock"),t.textContent="[□]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
 		function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
 		;const o=t.querySelector(".fs-btn")
 		;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")
@@ -365,8 +365,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('windy', this)">[HR]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('windy', this)">[ ]</a>
 							<a id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('windy', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">
@@ -483,8 +483,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('blitzortung', this)">[ ]</a>
 							<a id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('blitzortung', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,36 +42,37 @@
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
 		padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
-		align-items:center;justify-content:center;position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;background-color:#2b5797;color:
-		#fff;cursor:pointer;transform:translateZ(0)}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;background-color:#3a3f4a
-		;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
-		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;transform:translateZ(0)}.fs-exit-bar .fs-bar-btn{flex:1;display:flex;
+		align-items:center;justify-content:center;background-color:#2b5797;color:#fff;cursor:pointer}.fs-exit-bar .fs-bar-btn+.fs-bar-btn{
+		border-left:1px solid #1f3d6b}.fs-exit-bar .fs-exit{flex:2}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;
+		background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
+		scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
+		content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
+		pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:
+		linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -119,26 +120,28 @@
 		;o=o.replace(e.getAttribute(n),e.getAttribute(s))}e.src=o}function switchIframeZoom(e,t){
 		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
 		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getResetButtonFromFrameId(e)
-		;"[R]"===s.textContent&&(s.style.display="none")}function toggleFullscreen(e,t){dlog(`toggleFullscreen: ${e}`)
-		;const o=document.getElementById(e).parentElement;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{
-		const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
-		resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
-		o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
-		s&&(s.style.display="none");const r=document.createElement("div");r.className="fs-exit-bar",r.textContent="✕ Zatvori cijeli zaslon",
-		r.addEventListener("click",()=>exitFullscreen(o)),document.body.appendChild(r),o._fsExitBar=r}}function exitFullscreen(e){
+		;"[R]"!==s.textContent||n.parentElement.classList.contains("fullscreen")||(s.style.display="none")}function toggleFullscreen(e,t){
+		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
+		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
+		;if(o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
+		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s),
+		window.innerWidth<=800){const t=document.createElement("div");t.className="fs-exit-bar";const n=document.createElement("div")
+		;n.className="fs-bar-btn fs-reset",n.textContent="Reset",n.addEventListener("click",()=>resetIframePosition(e))
+		;const s=document.createElement("div");s.className="fs-bar-btn fs-exit",s.textContent="Zatvori",
+		s.addEventListener("click",()=>exitFullscreen(o)),t.append(s,n),document.body.appendChild(t),o._fsExitBar=t}}}function exitFullscreen(e){
 		e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
 		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
-		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
-		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
-		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
-		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
-		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
-		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=!1===e._fsOverlayVisible
+		;delete e._fsOverlayVisible;const s=e.querySelector(".overlay");s&&(n?s.style.display="none":s.removeAttribute("style"))
+		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(r.style.removeProperty("display"),
+		n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
+		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
+		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
+		;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
+		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
+		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
+		e.addEventListener("touchend",e=>{if(!n)return
 		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
@@ -151,10 +154,14 @@
 		dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 		e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
 		dlog(`Resetting iframe: ${e}`),setIframeSrc(document.getElementById(e));const t=getResetButtonFromFrameId(e);t.style.display="none",
-		setResetButtonToExit(t)}function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}
-		function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}
-		function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function GetLastInit(){
-		let e=new Date;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
+		setResetButtonToExit(t)}function resetIframePosition(e){dlog(`resetIframePosition: ${e}`),setIframeSrc(document.getElementById(e))}
+		function setResetButtonToFullscreenReset(e){dlog(`setResetButtonToFullscreenReset: ${e.id}`);const t=e.cloneNode(!0)
+		;e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{e.stopPropagation(),resetIframePosition(getFrameIdFromResetButtonId(t.id))}),
+		t.textContent="[R]",t.style.removeProperty("display")}function getResetButtonFromFrameId(e){
+		return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
+		return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
+		return document.getElementById(e).getAttribute("data-frame-id")}function GetLastInit(){let e=new Date
+		;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 		function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 		function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,11 +40,11 @@
 		:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
-		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
-		padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
-		position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;transform:translateZ(0)}.fs-exit-bar .fs-bar-btn{flex:1;display:flex;
-		align-items:center;justify-content:center;background-color:#2b5797;color:#fff;cursor:pointer}.fs-exit-bar .fs-bar-btn+.fs-bar-btn{
-		border-left:1px solid #1f3d6b}.fs-exit-bar .fs-exit{flex:2}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;
+		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;display:flex;align-items:center;justify-content:center}
+		.radartitle.fullscreen .center{transform:none;left:auto}.radartitle.fullscreen .left,.radartitle.fullscreen .right{top:50%;transform:
+		translateY(-50%)}.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}.if1.fullscreen{position:
+		fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}@media (max-width:800px){
+		.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}}.links-bottom{display:none;text-align:left;
 		background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
 		scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
 		content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
@@ -102,11 +102,11 @@
 		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,s=0,r=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
 		o=e.touches[0].clientY),r=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?r=!1:(n=e.touches[0].clientX,s=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,i=s-o
-		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,l=s-o
+		;Math.abs(r)>Math.abs(l)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseup",l=>{if(r){n=l.clientX,s=l.clientY;const i=n-t,a=s-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
 		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -123,18 +123,14 @@
 		;"[R]"!==s.textContent||n.parentElement.classList.contains("fullscreen")||(s.style.display="none")}function toggleFullscreen(e,t){
 		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
-		;if(o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s),
-		window.innerWidth<=800){const t=document.createElement("div");t.className="fs-exit-bar";const n=document.createElement("div")
-		;n.className="fs-bar-btn fs-reset",n.textContent="Reset",n.addEventListener("click",()=>resetIframePosition(e))
-		;const s=document.createElement("div");s.className="fs-bar-btn fs-exit",s.textContent="Zatvori",
-		s.addEventListener("click",()=>exitFullscreen(o)),t.append(s,n),document.body.appendChild(t),o._fsExitBar=t}}}function exitFullscreen(e){
-		e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
-		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
-		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=!1===e._fsOverlayVisible
-		;delete e._fsOverlayVisible;const s=e.querySelector(".overlay");s&&(n?s.style.display="none":s.removeAttribute("style"))
-		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(r.style.removeProperty("display"),
-		n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
+		;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
+		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+		function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
+		;const o=t.querySelector(".fs-btn")
+		;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")
+		;const n=!1===e._fsOverlayVisible;delete e._fsOverlayVisible;const s=e.querySelector(".overlay")
+		;s&&(n?s.style.display="none":s.removeAttribute("style"));const r=getResetButtonFromFrameId(e.querySelector("iframe").id)
+		;r&&(r.style.removeProperty("display"),n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
 		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
@@ -142,7 +138,7 @@
 		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
 		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
 		e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,l=Math.abs(t-r),i=Math.abs(o-s);l<10&&i<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,13 +128,17 @@
 		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
 		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
 		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
-		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
-		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
+		1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
+		const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
+		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function hideOverlayOnDoubleTap(){
+		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
+		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
+		;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
+		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
+		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
+		e.addEventListener("touchend",e=>{if(!n)return
 		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
@@ -156,7 +160,7 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
 		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
 		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,35 +41,36 @@
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%}body.fs-lock{
-		overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap
-		;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none
-		}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%;pointer-events:none}
+		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
+		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
+		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
+		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
+		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
+		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
+		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
+		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
+		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
+		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
+		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
+		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,7 +103,7 @@
 		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const a=n-t,l=s-o;Math.abs(a)>Math.abs(l)&&handleSwipe(e,t,n),r=!1}}),
 		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -131,7 +131,15 @@
 		function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
 		1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
 		const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
-		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function hideOverlayOnDoubleTap(){
+		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function addTapDebugReadout(){
+		if(!isDebugEnabled)return;const e=document.createElement("div");e.id="tapDebug",
+		e.style.cssText="position:fixed;left:0;right:0;bottom:0;z-index:2147483647;pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all",
+		e.textContent="tap debug ready",document.body.appendChild(e);const t={pointerdown:0,touchstart:0,touchend:0,click:0},o=(o,n)=>{t[o]++
+		;const s=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0]||n,r=Math.round(s&&s.clientX||0),i=Math.round(s&&s.clientY||0)
+		;e.textContent=`pd:${t.pointerdown} ts:${t.touchstart} te:${t.touchend} ck:${t.click}\nlast: ${o} @${r},${i}  fs:${!!document.querySelector(".if1.fullscreen")}\ntarget: ${(e=>{
+		if(!(e instanceof Element))return String(e);let t=e.tagName.toLowerCase();return e.id&&(t+="#"+e.id),
+		"string"==typeof e.className&&e.className.trim()&&(t+="."+e.className.trim().replace(/\s+/g,".")),t})(n.target)}`}
+		;["pointerdown","touchstart","touchend","click"].forEach(e=>document.addEventListener(e,t=>o(e,t),!0))}function hideOverlayOnDoubleTap(){
 		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
 		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
@@ -139,7 +147,7 @@
 		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
 		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
 		e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(o-s);i<10&&a<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -160,9 +168,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
-		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
-		updateHintText(),updateLinksScrollShadows()},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),addTapDebugReadout(),updateHintText(),initLinksBottom(),
+		addLinksScrollShadows()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{
+		updateIframeSrc(),updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
 	
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,36 +39,35 @@
 		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
 		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
 		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{
-		transform:none;width:100%;height:100%}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;
-		box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
-		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
+		.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto
+		;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
+		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,20 +40,21 @@
 		:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
-		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%;pointer-events:none}
-		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
-		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
-		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
-		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
-		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
-		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
-		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
-		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
-		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
-		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
-		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
+		padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
+		align-items:center;justify-content:center;position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;background-color:#2b5797;color:
+		#fff;cursor:pointer;transform:translateZ(0)}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;background-color:#3a3f4a
+		;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
 		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
 		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
 		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
@@ -104,7 +105,7 @@
 		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const a=n-t,l=s-o;Math.abs(a)>Math.abs(l)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
 		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -123,32 +124,22 @@
 		const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
 		resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
 		o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
-		s&&(s.style.display="none")}}function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling
+		s&&(s.style.display="none");const r=document.createElement("div");r.className="fs-exit-bar",r.textContent="✕ Zatvori cijeli zaslon",
+		r.addEventListener("click",()=>exitFullscreen(o)),document.body.appendChild(r),o._fsExitBar=r}}function exitFullscreen(e){
+		e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
 		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
 		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
 		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
 		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
 		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-		function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
-		1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
-		const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
-		;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function addTapDebugReadout(){
-		if(!isDebugEnabled)return;const e=document.createElement("div");e.id="tapDebug",
-		e.style.cssText="position:fixed;left:0;right:0;bottom:0;z-index:2147483647;pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all",
-		e.textContent="tap debug ready",document.body.appendChild(e);const t={pointerdown:0,touchstart:0,touchend:0,click:0},o=(o,n)=>{t[o]++
-		;const s=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0]||n,r=Math.round(s&&s.clientX||0),i=Math.round(s&&s.clientY||0)
-		;e.textContent=`pd:${t.pointerdown} ts:${t.touchstart} te:${t.touchend} ck:${t.click}\nlast: ${o} @${r},${i}  fs:${!!document.querySelector(".if1.fullscreen")}\ntarget: ${(e=>{
-		if(!(e instanceof Element))return String(e);let t=e.tagName.toLowerCase();return e.id&&(t+="#"+e.id),
-		"string"==typeof e.className&&e.className.trim()&&(t+="."+e.className.trim().replace(/\s+/g,".")),t})(n.target)}`}
-		;["pointerdown","touchstart","touchend","click"].forEach(e=>document.addEventListener(e,t=>o(e,t),!0))}function hideOverlayOnDoubleTap(){
-		document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
-		e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
-		;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
-		;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
-		;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
-		e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(o-s);i<10&&a<10&&(n.style.opacity="0.6",
+		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
+		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
+		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
+		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -169,9 +160,9 @@
 		return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 		isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 		e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-		updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),addTapDebugReadout(),updateHintText(),initLinksBottom(),
-		addLinksScrollShadows()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{
-		updateIframeSrc(),updateHintText(),updateLinksScrollShadows()},200)});
+		updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+		window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
+		updateHintText(),updateLinksScrollShadows()},200)});
 	</script>
 	
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-233EMZJM16"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,35 +41,35 @@
 		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-		left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:
-		#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
-		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
-		ease-in-out}
+		left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%}body.fs-lock{
+		overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap
+		;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none
+		}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
+		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,42 +30,45 @@
 		background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
 		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
 		position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
-		text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;
-		padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}
-		.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
-		background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
-		position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
-		position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
-		100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-		{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
-		-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
-		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		text-decoration:none;cursor:pointer}.radartitle .right-cluster{display:inline-flex;gap:8px}.radartitle .right-cluster a{text-decoration:none
+		;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}
+		@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;
+		transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}
+		@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:
+		hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:
+		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
+		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
+		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
+		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{
+		transform:none;width:100%;height:100%}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;
+		box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)
@@ -81,9 +84,9 @@
 		document.body.classList.toggle("show-links-bottom",e.checked))}function plusSlides(e,t){
 		const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 		function showSlides(e,t){
-		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-		;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
-		n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+		const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),s=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
+		;let r=t;r>n.length&&(r=1),r<1&&(r=n.length),e.setAttribute("data-current-slide",r),n.forEach(e=>e.classList.remove("active")),
+		n[r-1].classList.add("active"),s.forEach(e=>e.classList.remove("active")),s[r-1].classList.add("active"),updateSlideshowWidth(e)}
 		function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 		;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 		;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -92,15 +95,15 @@
 		e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 		n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 		const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
+		document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,s=0,r=!1;e.querySelectorAll("img").forEach(e=>{
 		e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
-		o=e.touches[0].clientY),s=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?s=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-		Math.abs(n-t)>Math.abs(r-o)&&(s=!0))}),e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o
-		;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+		o=e.touches[0].clientY),r=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?r=!1:(n=e.touches[0].clientX,s=e.touches[0].clientY,
+		Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,i=s-o
+		;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 		e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
-		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-		e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
-		e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+		e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
+		e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+		e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 		;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
 		document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
@@ -109,18 +112,29 @@
 		document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 		dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
 		;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
-		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
-		;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
+		const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",s="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
+		;o=o.replace(e.getAttribute(n),e.getAttribute(s))}e.src=o}function switchIframeZoom(e,t){
 		const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
-		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getResetButtonFromFrameId(e)
-		;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
-		let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-		setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-		if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),s=r-t;if(s>0&&s<200){e.style.display="none"
-		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
-		;const n=e.querySelector(".hint");let r=0,s=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(s=e.touches[0].clientX,
-		r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-s),a=Math.abs(o-r);i<10&&a<10&&(n.style.opacity="0.6",
+		t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getResetButtonFromFrameId(e)
+		;"[R]"===s.textContent&&(s.style.display="none")}function toggleFullscreen(e,t){dlog(`toggleFullscreen: ${e}`)
+		;const o=document.getElementById(e).parentElement;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{
+		const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
+		resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
+		o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
+		s&&(s.style.display="none")}}function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling
+		;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
+		document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
+		resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
+		;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
+		"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
+		function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
+		e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+		e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
+		if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
+		;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
+		;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+		s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+		;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 		clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 		const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 		t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -342,7 +356,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('windy', this)">[HR]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('windy', this)">[ ]</a>
+							<a id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="windy" loading="lazy" frameborder="0"
@@ -457,7 +474,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
-						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('blitzortung', this)">[ ]</a>
+							<a id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="blitzortung" loading="lazy" frameborder="0"

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,7 +124,7 @@
 		dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 		;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
 		;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-		document.body.classList.add("fs-lock"),t.textContent="[□]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+		document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
 		function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
 		;const o=t.querySelector(".fs-btn")
 		;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,35 +39,36 @@
 		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
 		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
 		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-		z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
-		.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto
-		;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
-		.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-		margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-		margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-		linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-		1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-		24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-		{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-		pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-		.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-		.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-		.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-		position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-		transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-		linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-		.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-		.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-		12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-		width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-		@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-		font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-		background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-		grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0
-		2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-		grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-		#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-		background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+		z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}
+		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
+		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
+		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
+		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
+		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
+		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
+		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
+		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
+		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
+		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
+		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
+		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+		background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+		text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+		.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+		@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+		grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+		.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+		center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+		border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+		.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+		.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+		@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+		100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+		height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s
+		ease-in-out}
 	</style>
 	<script>
 		function scrollToTop(){window.scrollTo({top:0,behavior:"smooth"})}function scrollToElement(e){const t=document.getElementById(e)

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,27 +31,28 @@
 		 3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
 		position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
 		text-decoration:none;cursor:pointer}.radartitle .right-cluster{display:inline-flex;gap:8px}.radartitle .right-cluster a{text-decoration:none
-		;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}
-		@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;
-		transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}
-		@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:
-		hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:
-		hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
-		transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
-		scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-		z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}
-		body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
-		white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-		.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
-		width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
-		}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
-		margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
-		.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
-		font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
-		49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
-		background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
-		background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
-		translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+		;cursor:pointer;position:relative}.radartitle .right-cluster a::before,.radartitle .zoom-btn::before{content:'';position:absolute;top:50%;
+		left:50%;transform:translate(-50%,-50%);width:26px;height:26px}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;
+		width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:
+		100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:
+		translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{
+		opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top
+		:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
+		100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
+		@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
+		.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
+		left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:
+		#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+		-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+		display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+		transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+		.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+		.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+		:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+		.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+		;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+		.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+		transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
 		translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
 		.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
 		transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -250,6 +250,10 @@ body.fs-lock {
 			border-left: 1px solid #1f3d6b;
 		}
 
+		.fs-exit-bar .fs-exit {
+			flex: 2; /* exit 2/3, reset 1/3 */
+		}
+
 	.if1.fullscreen {
 		bottom: 32px; /* reserve room for .fs-exit-bar */
 	}

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -200,19 +200,7 @@ iframe, video {
 	left: 0;
 	right: 0;
 	z-index: 10000;
-	transform: translateZ(0); /* own compositing layer: keeps taps working over the iframe on mobile */
 }
-
-	/* Inset the edge buttons out of Android's left/right gesture-nav zones.
-	   Touches starting in the ~20dp edge strips are swallowed by the OS for the
-	   back-swipe gesture, so a button flush against the edge never gets the tap. */
-	.radartitle.fullscreen .left {
-		margin-left: 36px;
-	}
-
-	.radartitle.fullscreen .right {
-		margin-right: 36px;
-	}
 
 .if1.fullscreen {
 	position: fixed;

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -231,51 +231,19 @@ body.fs-lock {
 	overflow: hidden;
 }
 
-/* Mobile-only "tap anywhere to exit" bar at the bottom. Big central target that
-   avoids the tiny edge buttons and the top address-bar zone. The iframe is held
-   off this strip (see .if1.fullscreen bottom below) so the bar sits over no
-   cross-origin iframe and stays reliably tappable while the map is interactive. */
-.fs-exit-bar {
-	display: none;
-}
-
 @media (max-width: 800px) {
-	.fs-exit-bar {
-		display: none; /* TEMP: bottom bar hidden for testing */
-		position: fixed;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		height: 32px;
-		z-index: 10000;
-		transform: translateZ(0);
-	}
-
-		.fs-exit-bar .fs-bar-btn {
-			flex: 1;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			background-color: #2b5797;
-			color: white;
-			cursor: pointer;
-		}
-
-		.fs-exit-bar .fs-bar-btn + .fs-bar-btn {
-			border-left: 1px solid #1f3d6b;
-		}
-
-		.fs-exit-bar .fs-exit {
-			flex: 2; /* exit 2/3, reset 1/3 */
-		}
-
+	/* taller fullscreen title bar so the centered buttons are reliably tappable */
 	.radartitle.fullscreen {
-		height: 32px; /* match the bottom bar height on mobile */
+		height: 32px;
 	}
 
 	.if1.fullscreen {
 		top: 32px; /* match the taller mobile title bar */
-		bottom: 0; /* TEMP: bottom bar hidden, let the map fill */
+	}
+
+	/* wider gap so the [-] and [R] tap areas don't overlap on touch screens */
+	.radartitle .right-cluster {
+		gap: 14px;
 	}
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -185,6 +185,7 @@ iframe, video {
 	left: 0;
 	right: 0;
 	z-index: 10000;
+	transform: translateZ(0); /* own compositing layer: keeps taps working over the iframe on mobile */
 }
 
 .if1.fullscreen {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -217,6 +217,15 @@ iframe, video {
 		transform: translateY(-50%);
 	}
 
+	/* gap from the screen edge in fullscreen (bar spans the full width) */
+	.radartitle.fullscreen .left {
+		margin-left: 10px;
+	}
+
+	.radartitle.fullscreen .right {
+		margin-right: 10px;
+	}
+
 .if1.fullscreen {
 	position: fixed;
 	top: 23px; /* matches .radartitle height */

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -217,15 +217,6 @@ iframe, video {
 		transform: translateY(-50%);
 	}
 
-	/* gap from the screen edge in fullscreen (bar spans the full width) */
-	.radartitle.fullscreen .left {
-		margin-left: 10px;
-	}
-
-	.radartitle.fullscreen .right {
-		margin-right: 10px;
-	}
-
 .if1.fullscreen {
 	position: fixed;
 	top: 23px; /* matches .radartitle height */
@@ -253,6 +244,15 @@ body.fs-lock {
 	/* wider gap so the [-] and [R] tap areas don't overlap on touch screens */
 	.radartitle .right-cluster {
 		gap: 14px;
+	}
+
+	/* gap from the screen edge in fullscreen (bar spans the full width) */
+	.radartitle.fullscreen .left {
+		margin-left: 10px;
+	}
+
+	.radartitle.fullscreen .right {
+		margin-right: 10px;
 	}
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -213,6 +213,15 @@ iframe, video {
 	z-index: 9999;
 }
 
+	/* EXPERIMENT: drop the scale transform on the cross-origin iframe in fullscreen.
+	   Transforms on OOPIFs are a suspected trigger for Chromium/Android hit-test
+	   misrouting (taps on the title routed into the iframe process). */
+	.if1.fullscreen .scaled-iframe {
+		transform: none;
+		width: 100%;
+		height: 100%;
+	}
+
 body.fs-lock {
 	overflow: hidden;
 }

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -200,7 +200,22 @@ iframe, video {
 	left: 0;
 	right: 0;
 	z-index: 10000;
+	display: flex;
+	align-items: center; /* vertically center the title items in a taller bar */
+	justify-content: center;
 }
+
+	/* flex centers the in-flow .center; the absolute side items center via top/translate */
+	.radartitle.fullscreen .center {
+		transform: none;
+		left: auto;
+	}
+
+	.radartitle.fullscreen .left,
+	.radartitle.fullscreen .right {
+		top: 50%;
+		transform: translateY(-50%);
+	}
 
 .if1.fullscreen {
 	position: fixed;
@@ -226,7 +241,7 @@ body.fs-lock {
 
 @media (max-width: 800px) {
 	.fs-exit-bar {
-		display: flex;
+		display: none; /* TEMP: bottom bar hidden for testing */
 		position: fixed;
 		left: 0;
 		right: 0;
@@ -254,8 +269,13 @@ body.fs-lock {
 			flex: 2; /* exit 2/3, reset 1/3 */
 		}
 
+	.radartitle.fullscreen {
+		height: 32px; /* match the bottom bar height on mobile */
+	}
+
 	.if1.fullscreen {
-		bottom: 32px; /* reserve room for .fs-exit-bar */
+		top: 32px; /* match the taller mobile title bar */
+		bottom: 0; /* TEMP: bottom bar hidden, let the map fill */
 	}
 }
 

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -213,13 +213,15 @@ iframe, video {
 	z-index: 9999;
 }
 
-	/* EXPERIMENT: drop the scale transform on the cross-origin iframe in fullscreen.
-	   Transforms on OOPIFs are a suspected trigger for Chromium/Android hit-test
-	   misrouting (taps on the title routed into the iframe process). */
+	/* EXPERIMENT: transform ruled out as the OOPIF hit-test trigger. Now testing
+	   whether removing the iframe from hit-testing entirely (pointer-events: none)
+	   lets taps reach the main-frame title bar. NOTE: this also makes the map
+	   non-interactive in fullscreen — temporary, just to confirm the lever works. */
 	.if1.fullscreen .scaled-iframe {
 		transform: none;
 		width: 100%;
 		height: 100%;
+		pointer-events: none;
 	}
 
 body.fs-lock {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -70,6 +70,16 @@ table {
 		cursor: pointer;
 	}
 
+	.radartitle .right-cluster {
+		display: inline-flex;
+		gap: 8px;
+	}
+
+		.radartitle .right-cluster a {
+			text-decoration: none;
+			cursor: pointer;
+		}
+
 img {
 	max-width: 100%;
 	height: auto;
@@ -166,6 +176,35 @@ iframe, video {
 		height: calc(100% / 0.6);
 		transform-origin: 0 0;
 	}
+}
+
+/* fullscreen takeover: title row pinned to top, map fills the rest */
+.radartitle.fullscreen {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 10000;
+}
+
+.if1.fullscreen {
+	position: fixed;
+	top: 23px; /* matches .radartitle height */
+	left: 0;
+	right: 0;
+	bottom: 0;
+	padding-top: 0;
+	z-index: 9999;
+}
+
+	.if1.fullscreen .scaled-iframe {
+		transform: none;
+		width: 100%;
+		height: 100%;
+	}
+
+body.fs-lock {
+	overflow: hidden;
 }
 
 .links-bottom {

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -78,7 +78,22 @@ table {
 		.radartitle .right-cluster a {
 			text-decoration: none;
 			cursor: pointer;
+			position: relative; /* anchor for the enlarged tap area below */
 		}
+
+	/* enlarge the tap target around the small title-bar glyphs (HR/EU, fullscreen,
+	   reset) for easier tapping on touch screens — same trick as .links-toggle::before
+	   (.left/.zoom-btn is already positioned, so its ::before anchors to it) */
+	.radartitle .zoom-btn::before,
+	.radartitle .right-cluster a::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 26px;
+		height: 26px;
+	}
 
 img {
 	max-width: 100%;

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -197,12 +197,6 @@ iframe, video {
 	z-index: 9999;
 }
 
-	.if1.fullscreen .scaled-iframe {
-		transform: none;
-		width: 100%;
-		height: 100%;
-	}
-
 body.fs-lock {
 	overflow: hidden;
 }

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -227,19 +227,28 @@ body.fs-lock {
 @media (max-width: 800px) {
 	.fs-exit-bar {
 		display: flex;
-		align-items: center;
-		justify-content: center;
 		position: fixed;
 		left: 0;
 		right: 0;
 		bottom: 0;
 		height: 32px;
 		z-index: 10000;
-		background-color: #2b5797;
-		color: white;
-		cursor: pointer;
 		transform: translateZ(0);
 	}
+
+		.fs-exit-bar .fs-bar-btn {
+			flex: 1;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			background-color: #2b5797;
+			color: white;
+			cursor: pointer;
+		}
+
+		.fs-exit-bar .fs-bar-btn + .fs-bar-btn {
+			border-left: 1px solid #1f3d6b;
+		}
 
 	.if1.fullscreen {
 		bottom: 32px; /* reserve room for .fs-exit-bar */

--- a/src/_assets/css/styles.css
+++ b/src/_assets/css/styles.css
@@ -203,6 +203,17 @@ iframe, video {
 	transform: translateZ(0); /* own compositing layer: keeps taps working over the iframe on mobile */
 }
 
+	/* Inset the edge buttons out of Android's left/right gesture-nav zones.
+	   Touches starting in the ~20dp edge strips are swallowed by the OS for the
+	   back-swipe gesture, so a button flush against the edge never gets the tap. */
+	.radartitle.fullscreen .left {
+		margin-left: 36px;
+	}
+
+	.radartitle.fullscreen .right {
+		margin-right: 36px;
+	}
+
 .if1.fullscreen {
 	position: fixed;
 	top: 23px; /* matches .radartitle height */
@@ -213,19 +224,38 @@ iframe, video {
 	z-index: 9999;
 }
 
-	/* EXPERIMENT: transform ruled out as the OOPIF hit-test trigger. Now testing
-	   whether removing the iframe from hit-testing entirely (pointer-events: none)
-	   lets taps reach the main-frame title bar. NOTE: this also makes the map
-	   non-interactive in fullscreen — temporary, just to confirm the lever works. */
-	.if1.fullscreen .scaled-iframe {
-		transform: none;
-		width: 100%;
-		height: 100%;
-		pointer-events: none;
-	}
-
 body.fs-lock {
 	overflow: hidden;
+}
+
+/* Mobile-only "tap anywhere to exit" bar at the bottom. Big central target that
+   avoids the tiny edge buttons and the top address-bar zone. The iframe is held
+   off this strip (see .if1.fullscreen bottom below) so the bar sits over no
+   cross-origin iframe and stays reliably tappable while the map is interactive. */
+.fs-exit-bar {
+	display: none;
+}
+
+@media (max-width: 800px) {
+	.fs-exit-bar {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: fixed;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: 32px;
+		z-index: 10000;
+		background-color: #2b5797;
+		color: white;
+		cursor: pointer;
+		transform: translateZ(0);
+	}
+
+	.if1.fullscreen {
+		bottom: 32px; /* reserve room for .fs-exit-bar */
+	}
 }
 
 .links-bottom {

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -12,33 +12,32 @@ hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;paddi
 hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
 transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
 scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{
-transform:none;width:100%;height:100%}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;
-box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
--ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
-ease-in-out}
+z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
+.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto
+;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
+.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
+2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -15,9 +15,9 @@ opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.v
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 .radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;display:flex;align-items:center;justify-content:center}
 .radartitle.fullscreen .center{transform:none;left:auto}.radartitle.fullscreen .left,.radartitle.fullscreen .right{top:50%;transform:
-translateY(-50%)}.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}.if1.fullscreen{position:
-fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}@media (max-width:800px){
-.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}}.links-bottom{display:none;text-align:left;
+translateY(-50%)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
+@media (max-width:800px){.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}
+.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}}.links-bottom{display:none;text-align:left;
 background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
 scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
 content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -13,11 +13,11 @@ opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.v
 :67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
 100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
-.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
-padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
-position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;transform:translateZ(0)}.fs-exit-bar .fs-bar-btn{flex:1;display:flex;
-align-items:center;justify-content:center;background-color:#2b5797;color:#fff;cursor:pointer}.fs-exit-bar .fs-bar-btn+.fs-bar-btn{
-border-left:1px solid #1f3d6b}.fs-exit-bar .fs-exit{flex:2}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;
+.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;display:flex;align-items:center;justify-content:center}
+.radartitle.fullscreen .center{transform:none;left:auto}.radartitle.fullscreen .left,.radartitle.fullscreen .right{top:50%;transform:
+translateY(-50%)}.radartitle.fullscreen .left{margin-left:10px}.radartitle.fullscreen .right{margin-right:10px}.if1.fullscreen{position:
+fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}@media (max-width:800px){
+.radartitle.fullscreen{height:32px}.if1.fullscreen{top:32px}.radartitle .right-cluster{gap:14px}}.links-bottom{display:none;text-align:left;
 background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
 scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
 content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -14,32 +14,32 @@ opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.v
 100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 .radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:
-#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
--ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
-ease-in-out}
+left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%}body.fs-lock{
+overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap
+;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none
+}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
+margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
+margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
+2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -3,39 +3,42 @@ text-decoration:none}a:hover{text-decoration:underline}table{width:100%;max-widt
 background-color:#202c40}.radartitle{position:relative;max-width:100%;background-color:#2b5797;box-sizing:border-box;height:23px;padding:4px
  3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
 position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
-text-decoration:none;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;
-padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}
-.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);
-background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{
-position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{
-position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:
-100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
-@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.links-bottom
-{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;
--webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
-.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
-2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+text-decoration:none;cursor:pointer}.radartitle .right-cluster{display:inline-flex;gap:8px}.radartitle .right-cluster a{text-decoration:none
+;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}
+@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;
+transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}
+@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:
+hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:
+hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
+transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
+scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
+z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{
+transform:none;width:100%;height:100%}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;
+box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
+ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -12,32 +12,33 @@ hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;paddi
 hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
 transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
 scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}
-.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto
-;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}
-.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
-2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}
+body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
+white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
+.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
+width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
+}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
+margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
+.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
+font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
+49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
+background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
+background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
+translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
+ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -4,27 +4,28 @@ background-color:#202c40}.radartitle{position:relative;max-width:100%;background
  3px}.radartitle .center{transform:translateX(-50%);left:50%}.radartitle .left{position:absolute;left:0;margin-left:3px}.radartitle .right{
 position:absolute;right:0;margin-right:3px;text-decoration:none}.radartitle .right:hover{cursor:pointer}.radartitle .zoom-btn{
 text-decoration:none;cursor:pointer}.radartitle .right-cluster{display:inline-flex;gap:8px}.radartitle .right-cluster a{text-decoration:none
-;cursor:pointer}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;width:100%;overflow:hidden;padding-top:90%}
-@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:100%;height:100%}.overlay .hint{opacity:0;
-transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:translateX(-50%);background-color:#000;padding:6px 12px}
-@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{opacity:.6}.if2{position:relative;width:100%;overflow:
-hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top:67%}.vid2{position:relative;width:100%;overflow:
-hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:100%;height:100%;border:none}.scaled-iframe{
-transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}@media (max-width:800px){.scaled-iframe{transform:
-scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;
-z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;padding-top:0;z-index:9999}
-body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
-white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
-width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
-}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
-margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
-.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
-font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
-49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
-background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
-background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
-translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+;cursor:pointer;position:relative}.radartitle .right-cluster a::before,.radartitle .zoom-btn::before{content:'';position:absolute;top:50%;
+left:50%;transform:translate(-50%,-50%);width:26px;height:26px}img{max-width:100%;height:auto;display:block;border:0}.if1{position:relative;
+width:100%;overflow:hidden;padding-top:90%}@media (max-width:800px){.if1{padding-top:110%}}.overlay{position:absolute;top:0;left:0;width:
+100%;height:100%}.overlay .hint{opacity:0;transition:opacity .3s ease;pointer-events:none;position:absolute;top:5%;transform:
+translateX(-50%);background-color:#000;padding:6px 12px}@media (max-width:800px){.overlay .hint{top:10%;min-width:65%}}.overlay:hover .hint{
+opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.vid1{position:relative;width:100%;overflow:hidden;padding-top
+:67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
+100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
+@media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
+.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
+left:0;right:0;bottom:0;padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:
+#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
 translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
 .slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
 transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -14,32 +14,33 @@ opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.v
 100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 .radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%}body.fs-lock{
-overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap
-;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none
-}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;
-margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;
-margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
-linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
-1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
-24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
-{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
-pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
-.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
-.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
-.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
-position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
-transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
-linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
-.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
-.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
-12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
-width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
-@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
-font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
-background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
-grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
-2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
-grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
-#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
-background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}
+left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%;pointer-events:none}
+body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
+white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
+.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
+width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
+}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
+margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
+.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
+font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
+49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
+background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
+background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
+translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
+.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
+transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
+background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
+text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
+.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
+@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
+grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
+.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
+center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
+border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
+.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
+.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
+@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
+100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
+height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
+ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -15,33 +15,34 @@ opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.v
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
 .radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
 padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
-align-items:center;justify-content:center;position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;background-color:#2b5797;color:
-#fff;cursor:pointer;transform:translateZ(0)}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;background-color:#3a3f4a
-;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
--ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
-display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
-transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
-.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
-.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
-:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
-.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
-;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
-.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
-transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
-translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
-.slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
-transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{
-background-image:linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;
-text-align:right}.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}
-.next.shorter{top:23px}.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}
-@media (max-width:800px){.next,.prev{padding:12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;
-grid-template-columns:repeat(3,1fr);gap:4px;width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}
-.indicator.active{background-color:#ff9800}@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:
-center;margin-top:10px;margin-bottom:4px;font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;
-border:none;outline:0}.expandable:hover{background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}
-.links{font-size:14px;display:grid;grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}
-.links .item{padding:5px;margin:0 2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}
-@media (max-width:800px){.links{grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:
-100%;background:#485871;color:#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;
-height:3px;z-index:1000;background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s 
-ease-in-out}
+position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;transform:translateZ(0)}.fs-exit-bar .fs-bar-btn{flex:1;display:flex;
+align-items:center;justify-content:center;background-color:#2b5797;color:#fff;cursor:pointer}.fs-exit-bar .fs-bar-btn+.fs-bar-btn{
+border-left:1px solid #1f3d6b}.fs-exit-bar .fs-exit{flex:2}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;
+background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;
+scrollbar-width:none;-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{
+content:"";position:sticky;display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;
+pointer-events:none;opacity:0;transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:
+linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;margin-left:-24px;background:
+linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:
+1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:
+24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn
+{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:
+pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}
+.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:translateY(-50%);margin:0;cursor:pointer}
+.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:28px;height:28px}
+.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}.slide.active{display:block}.next,.prev{cursor:pointer;
+position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:transparent;opacity:.7;font-weight:700;font-size:36px;
+transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{background-image:
+linear-gradient(to left,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.prev.shorter{top:23px}.next{right:0;text-align:right}
+.next:hover{background-image:linear-gradient(to right,transparent,rgba(0,0,0,.6));color:#fff;text-decoration:none}.next.shorter{top:23px}
+.fade{animation-name:fade;animation-duration:1s}@keyframes fade{from{opacity:.6}to{opacity:1}}@media (max-width:800px){.next,.prev{padding:
+12px;font-size:20px}.next.shorter,.prev.shorter{top:23px}}.indicators-container{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;
+width:100%}.indicator{height:3px;background-color:#4e5264;transition:background-color .3s}.indicator.active{background-color:#ff9800}
+@media (max-width:800px){.indicator{height:2px}}.expandable{position:relative;justify-content:center;margin-top:10px;margin-bottom:4px;
+font-family:inherit;color:#fff;background-color:#485871;cursor:pointer;width:100%;height:24px;border:none;outline:0}.expandable:hover{
+background-color:#5f6f89}.expandable .arrow{position:absolute;right:10px;top:2px;font-size:14px}.links{font-size:14px;display:grid;
+grid-template-columns:25% 45% 30%;gap:0;max-height:0;overflow:hidden;transition:max-height .3s ease-out}.links .item{padding:5px;margin:0 
+2px}.links .item:not(:last-child){border-right:1px solid #fff}.links p{margin-top:0;text-align:left}@media (max-width:800px){.links{
+grid-template-columns:1fr}.links .item{margin:5px 0;border-right:none!important}}footer{position:sticky;top:100%;background:#485871;color:
+#fff;text-align:center;padding:8px;margin-top:8px}.progress-container{position:fixed;left:0;top:0;width:100%;height:3px;z-index:1000;
+background-color:#5c5c5c80}.progress-bar{width:0;height:100%;background-color:#4caf50;transition:width .3s ease-in-out}

--- a/src/_assets/css/styles.min.css
+++ b/src/_assets/css/styles.min.css
@@ -13,20 +13,21 @@ opacity:.6}.if2{position:relative;width:100%;overflow:hidden;padding-top:115%}.v
 :67%}.vid2{position:relative;width:100%;overflow:hidden;padding-top:87%}iframe,video{position:absolute;top:0;left:0;bottom:0;right:0;width:
 100%;height:100%;border:none}.scaled-iframe{transform:scale(.9);width:calc(100% / .9);height:calc(100% / .9);transform-origin:0 0}
 @media (max-width:800px){.scaled-iframe{transform:scale(.6);width:calc(100% / .6);height:calc(100% / .6);transform-origin:0 0}}
-.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000;transform:translateZ(0)}.if1.fullscreen{position:fixed;top:23px;
-left:0;right:0;bottom:0;padding-top:0;z-index:9999}.if1.fullscreen .scaled-iframe{transform:none;width:100%;height:100%;pointer-events:none}
-body.fs-lock{overflow:hidden}.links-bottom{display:none;text-align:left;background-color:#3a3f4a;box-sizing:border-box;padding:5px 4px;
-white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;display:inline-block;
-width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;transition:opacity .2s ease
-}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}.links-bottom::after{right:-4px;
-margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}.links-bottom.can-scroll-left::before{opacity:1}
-.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display:block}@media (max-width:800px){.links-bottom{
-font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}.buttons{display:grid;grid-template-columns:
-49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px;font-family:inherit;color:#fff;
-background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}.buttons .btn:hover{
-background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;transform:
-translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
+.radartitle.fullscreen{position:fixed;top:0;left:0;right:0;z-index:10000}.if1.fullscreen{position:fixed;top:23px;left:0;right:0;bottom:0;
+padding-top:0;z-index:9999}body.fs-lock{overflow:hidden}.fs-exit-bar{display:none}@media (max-width:800px){.fs-exit-bar{display:flex;
+align-items:center;justify-content:center;position:fixed;left:0;right:0;bottom:0;height:32px;z-index:10000;background-color:#2b5797;color:
+#fff;cursor:pointer;transform:translateZ(0)}.if1.fullscreen{bottom:32px}}.links-bottom{display:none;text-align:left;background-color:#3a3f4a
+;box-sizing:border-box;padding:5px 4px;white-space:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+-ms-overflow-style:none}.links-bottom::-webkit-scrollbar{display:none}.links-bottom::after,.links-bottom::before{content:"";position:sticky;
+display:inline-block;width:24px;height:1.4em;margin-top:-.3em;margin-bottom:-.3em;vertical-align:middle;pointer-events:none;opacity:0;
+transition:opacity .2s ease}.links-bottom::before{left:-4px;margin-right:-24px;background:linear-gradient(to left,transparent,#3a3f4a)}
+.links-bottom::after{right:-4px;margin-left:-24px;background:linear-gradient(to right,transparent,#3a3f4a)}
+.links-bottom.can-scroll-left::before{opacity:1}.links-bottom.can-scroll-right::after{opacity:1}body.show-links-bottom .links-bottom{display
+:block}@media (max-width:800px){.links-bottom{font-size:12px}}.sp{height:12px}.sp20{height:24px}@media (max-width:800px){.sp20{height:12px}}
+.buttons{display:grid;grid-template-columns:49.5% 49.5%;gap:1%;font-size:13px}.buttons .btn{margin-top:10px;margin-bottom:5px;font-size:13px
+;font-family:inherit;color:#fff;background-color:#485871;align-content:center;cursor:pointer;width:100%;height:24px;border:none;outline:0}
+.buttons .btn:hover{background-color:#5f6f89}.links-btn{position:relative}.links-btn .links-toggle{position:absolute;right:8px;top:22px;
+transform:translateY(-50%);margin:0;cursor:pointer}.links-btn .links-toggle::before{content:'';position:absolute;top:50%;left:50%;transform:
 translate(-50%,-50%);width:28px;height:28px}.slideshow{position:relative;display:flex;justify-content:center}.slide{display:none}
 .slide.active{display:block}.next,.prev{cursor:pointer;position:absolute;align-content:center;top:0;bottom:0;width:15%;padding:16px;color:
 transparent;opacity:.7;font-weight:700;font-size:36px;transition:.6s ease;user-select:none}.prev{left:0;text-align:left}.prev:hover{

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -313,34 +313,13 @@ function toggleFullscreen(frameId, btn) {
 		// unlock interactivity: drop the overlay gate
 		if (overlay) overlay.style.display = 'none';
 		// show [R] in the top bar to reset the map to default without leaving
-		// fullscreen (reliable on desktop; mobile uses the bottom bar's Reset)
+		// fullscreen; it reloads and stays available for repeated use
 		if (resetBtn) setResetButtonToFullscreenReset(resetBtn);
-		// mobile-only bottom bar (matches the CSS <=800px breakpoint): big reliable
-		// Zatvori | Reset targets, where the tiny top-bar edge buttons aren't reachable
-		if (window.innerWidth <= 800) {
-			const exitBar = document.createElement('div');
-			exitBar.className = 'fs-exit-bar';
-			const resetZone = document.createElement('div');
-			resetZone.className = 'fs-bar-btn fs-reset';
-			resetZone.textContent = 'Reset';
-			resetZone.addEventListener('click', () => resetIframePosition(frameId));
-			const exitZone = document.createElement('div');
-			exitZone.className = 'fs-bar-btn fs-exit';
-			exitZone.textContent = 'Zatvori';
-			exitZone.addEventListener('click', () => exitFullscreen(if1));
-			exitBar.append(exitZone, resetZone);
-			document.body.appendChild(exitBar);
-			if1._fsExitBar = exitBar;
-		}
 	}
 }
 
 function exitFullscreen(if1) {
 	if1.classList.remove('fullscreen');
-	if (if1._fsExitBar) { // remove the mobile exit bar (all exit paths land here)
-		if1._fsExitBar.remove();
-		delete if1._fsExitBar;
-	}
 	const title = if1.previousElementSibling;
 	title.classList.remove('fullscreen');
 	const btn = title.querySelector('.fs-btn');

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -309,7 +309,7 @@ function toggleFullscreen(frameId, btn) {
 		if1.classList.add('fullscreen');
 		if1.previousElementSibling.classList.add('fullscreen');
 		document.body.classList.add('fs-lock');
-		btn.textContent = '[□]';
+		btn.textContent = '[-]';
 		// unlock interactivity: drop the overlay gate
 		if (overlay) overlay.style.display = 'none';
 		// show [R] in the top bar to reset the map to default without leaving

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -315,11 +315,23 @@ function toggleFullscreen(frameId, btn) {
 		// unlock interactivity: drop the overlay gate and hide the reset button
 		if (overlay) overlay.style.display = 'none';
 		if (resetBtn) resetBtn.style.display = 'none';
+		// big mobile exit target (CSS hides it on desktop) — reliable where the
+		// tiny edge buttons aren't, since it sits over no cross-origin iframe
+		const exitBar = document.createElement('div');
+		exitBar.className = 'fs-exit-bar';
+		exitBar.textContent = '✕ Zatvori cijeli zaslon';
+		exitBar.addEventListener('click', () => exitFullscreen(if1));
+		document.body.appendChild(exitBar);
+		if1._fsExitBar = exitBar;
 	}
 }
 
 function exitFullscreen(if1) {
 	if1.classList.remove('fullscreen');
+	if (if1._fsExitBar) { // remove the mobile exit bar (all exit paths land here)
+		if1._fsExitBar.remove();
+		delete if1._fsExitBar;
+	}
 	const title = if1.previousElementSibling;
 	title.classList.remove('fullscreen');
 	const btn = title.querySelector('.fs-btn');

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -372,6 +372,46 @@ function addTitleTapActivation() {
 	});
 }
 
+function addTapDebugReadout() {
+	// DEBUG (?debug=1 only): on-screen readout to confirm whether taps reach the
+	// main frame at all. Capture-phase listeners on document fire for any event the
+	// main frame receives, before handlers/stopPropagation. If you tap a "dead"
+	// title button and NO counter moves -> the tap was routed to the cross-origin
+	// iframe's process (OOPIF misrouting). If pd/ts/te move but ck doesn't -> the
+	// click is being swallowed. If all move with target = the <a> -> handler issue.
+	if (!isDebugEnabled) return;
+
+	const box = document.createElement('div');
+	box.id = 'tapDebug';
+	box.style.cssText = 'position:fixed;left:0;right:0;bottom:0;z-index:2147483647;'
+		+ 'pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;'
+		+ 'font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all';
+	box.textContent = 'tap debug ready';
+	document.body.appendChild(box);
+
+	const counts = { pointerdown: 0, touchstart: 0, touchend: 0, click: 0 };
+	const describe = (t) => {
+		if (!(t instanceof Element)) return String(t);
+		let s = t.tagName.toLowerCase();
+		if (t.id) s += '#' + t.id;
+		if (typeof t.className === 'string' && t.className.trim())
+			s += '.' + t.className.trim().replace(/\s+/g, '.');
+		return s;
+	};
+	const render = (type, e) => {
+		counts[type]++;
+		const p = (e.touches && e.touches[0]) || (e.changedTouches && e.changedTouches[0]) || e;
+		const x = Math.round((p && p.clientX) || 0);
+		const y = Math.round((p && p.clientY) || 0);
+		box.textContent =
+			`pd:${counts.pointerdown} ts:${counts.touchstart} te:${counts.touchend} ck:${counts.click}\n`
+			+ `last: ${type} @${x},${y}  fs:${!!document.querySelector('.if1.fullscreen')}\n`
+			+ `target: ${describe(e.target)}`;
+	};
+	['pointerdown', 'touchstart', 'touchend', 'click'].forEach(type =>
+		document.addEventListener(type, (e) => render(type, e), true));
+}
+
 function hideOverlayOnDoubleTap() {
 	const overlays = document.querySelectorAll('.if1 .overlay');
 
@@ -554,6 +594,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	updateIframeSrc();
 	hideOverlayOnDoubleTap();
 	addTitleTapActivation();
+	addTapDebugReadout();
 	updateHintText();
 	initLinksBottom();
 	addLinksScrollShadows();

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -540,8 +540,3 @@ window.addEventListener('resize', () => {
 		updateLinksScrollShadows();
 	}, 200);
 });
-
-document.addEventListener('keydown', (e) => {
-	if (e.key === 'Escape')
-		document.querySelectorAll('.if1.fullscreen').forEach(exitFullscreen);
-});

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -358,72 +358,6 @@ function exitFullscreen(if1) {
 	delete if1._fsPrevState;
 }
 
-function addTitleTapActivation() {
-	// On mobile, the synthetic click after interacting with a cross-origin iframe
-	// (e.g. tapping the map's own zoom controls) can be swallowed, leaving the
-	// title-bar buttons unresponsive. Fire the action on touchend instead and
-	// preventDefault to suppress the now-redundant synthetic click (no double-fire).
-	// Delegated on .radartitle so it survives the reset button being recloned.
-	const sel = '.zoom-btn, .fs-btn, .right-cluster a';
-	document.querySelectorAll('.radartitle').forEach(bar => {
-		let sx = 0, sy = 0;
-		bar.addEventListener('touchstart', (e) => {
-			if (e.touches.length === 1) {
-				sx = e.touches[0].clientX;
-				sy = e.touches[0].clientY;
-			}
-		}, { passive: true });
-		bar.addEventListener('touchend', (e) => {
-			const a = e.target.closest('a');
-			if (!a || !bar.contains(a) || !a.matches(sel)) return;
-			const t = e.changedTouches[0];
-			if (Math.abs(t.clientX - sx) > 10 || Math.abs(t.clientY - sy) > 10) return; // treat as scroll/swipe
-			e.preventDefault(); // stop the (possibly swallowed) synthetic click from firing too
-			a.click();
-		});
-	});
-}
-
-function addTapDebugReadout() {
-	// DEBUG (?debug=1 only): on-screen readout to confirm whether taps reach the
-	// main frame at all. Capture-phase listeners on document fire for any event the
-	// main frame receives, before handlers/stopPropagation. If you tap a "dead"
-	// title button and NO counter moves -> the tap was routed to the cross-origin
-	// iframe's process (OOPIF misrouting). If pd/ts/te move but ck doesn't -> the
-	// click is being swallowed. If all move with target = the <a> -> handler issue.
-	if (!isDebugEnabled) return;
-
-	const box = document.createElement('div');
-	box.id = 'tapDebug';
-	box.style.cssText = 'position:fixed;left:0;right:0;bottom:0;z-index:2147483647;'
-		+ 'pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;'
-		+ 'font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all';
-	box.textContent = 'tap debug ready';
-	document.body.appendChild(box);
-
-	const counts = { pointerdown: 0, touchstart: 0, touchend: 0, click: 0 };
-	const describe = (t) => {
-		if (!(t instanceof Element)) return String(t);
-		let s = t.tagName.toLowerCase();
-		if (t.id) s += '#' + t.id;
-		if (typeof t.className === 'string' && t.className.trim())
-			s += '.' + t.className.trim().replace(/\s+/g, '.');
-		return s;
-	};
-	const render = (type, e) => {
-		counts[type]++;
-		const p = (e.touches && e.touches[0]) || (e.changedTouches && e.changedTouches[0]) || e;
-		const x = Math.round((p && p.clientX) || 0);
-		const y = Math.round((p && p.clientY) || 0);
-		box.textContent =
-			`pd:${counts.pointerdown} ts:${counts.touchstart} te:${counts.touchend} ck:${counts.click}\n`
-			+ `last: ${type} @${x},${y}  fs:${!!document.querySelector('.if1.fullscreen')}\n`
-			+ `target: ${describe(e.target)}`;
-	};
-	['pointerdown', 'touchstart', 'touchend', 'click'].forEach(type =>
-		document.addEventListener(type, (e) => render(type, e), true));
-}
-
 function hideOverlayOnDoubleTap() {
 	const overlays = document.querySelectorAll('.if1 .overlay');
 
@@ -605,8 +539,6 @@ document.addEventListener('DOMContentLoaded', () => {
 	addSwipeEvents();
 	updateIframeSrc();
 	hideOverlayOnDoubleTap();
-	addTitleTapActivation();
-	addTapDebugReadout();
 	updateHintText();
 	initLinksBottom();
 	addLinksScrollShadows();

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -306,15 +306,24 @@ function toggleFullscreen(frameId, btn) {
 		if1.previousElementSibling.classList.add('fullscreen');
 		document.body.classList.add('fs-lock');
 		btn.textContent = '[-]';
-		// unlock interactivity: drop the overlay gate and hide the reset button
+		// unlock interactivity: drop the overlay gate
 		if (overlay) overlay.style.display = 'none';
-		if (resetBtn) resetBtn.style.display = 'none';
-		// big mobile exit target (CSS hides it on desktop) — reliable where the
-		// tiny edge buttons aren't, since it sits over no cross-origin iframe
+		// show [R] in the top bar to reset the map to default without leaving
+		// fullscreen (reliable on desktop; mobile uses the bottom bar's Reset)
+		if (resetBtn) setResetButtonToFullscreenReset(resetBtn);
+		// mobile bottom bar (CSS hides it on desktop): big reliable Reset | Exit
+		// targets, where the tiny top-bar edge buttons aren't reachable
 		const exitBar = document.createElement('div');
 		exitBar.className = 'fs-exit-bar';
-		exitBar.textContent = '✕ Zatvori cijeli zaslon';
-		exitBar.addEventListener('click', () => exitFullscreen(if1));
+		const resetZone = document.createElement('div');
+		resetZone.className = 'fs-bar-btn';
+		resetZone.textContent = 'Reset';
+		resetZone.addEventListener('click', () => resetIframePosition(frameId));
+		const exitZone = document.createElement('div');
+		exitZone.className = 'fs-bar-btn';
+		exitZone.textContent = 'Zatvori';
+		exitZone.addEventListener('click', () => exitFullscreen(if1));
+		exitBar.append(exitZone, resetZone);
 		document.body.appendChild(exitBar);
 		if1._fsExitBar = exitBar;
 	}
@@ -471,6 +480,26 @@ function resetIframe(frameId) {
 	const resetFrame = getResetButtonFromFrameId(frameId);
 	resetFrame.style.display = 'none';
 	setResetButtonToExit(resetFrame);
+}
+
+// reload the map to its default position/zoom without changing the button —
+// used while in fullscreen, where reset must stay available for repeated use
+function resetIframePosition(frameId) {
+	dlog(`resetIframePosition: ${frameId}`);
+	setIframeSrc(document.getElementById(frameId));
+}
+
+function setResetButtonToFullscreenReset(resetFrame) {
+	dlog(`setResetButtonToFullscreenReset: ${resetFrame.id}`);
+	const newResetFrame = resetFrame.cloneNode(true);
+	resetFrame.parentNode.replaceChild(newResetFrame, resetFrame);
+
+	newResetFrame.addEventListener('click', (e) => {
+		e.stopPropagation(); // Stop event bubbling
+		resetIframePosition(getFrameIdFromResetButtonId(newResetFrame.id));
+	});
+	newResetFrame.textContent = '[R]';
+	newResetFrame.style.removeProperty('display'); // ensure visible in fullscreen
 }
 
 function getResetButtonFromFrameId(frameId) {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -309,7 +309,7 @@ function toggleFullscreen(frameId, btn) {
 		if1.classList.add('fullscreen');
 		if1.previousElementSibling.classList.add('fullscreen');
 		document.body.classList.add('fs-lock');
-		btn.textContent = '[-]';
+		btn.textContent = '[□]';
 		// unlock interactivity: drop the overlay gate
 		if (overlay) overlay.style.display = 'none';
 		// show [R] in the top bar to reset the map to default without leaving

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -291,7 +291,9 @@ function switchIframeZoom(frameId, btn) {
 	btn.setAttribute('data-mode', newMode);
 	btn.textContent = newMode === 'hr' ? '[HR]' : '[EU]';
 	const resetBtn = getResetButtonFromFrameId(frameId);
-	if (resetBtn.textContent === '[R]') resetBtn.style.display = 'none';
+	// only the gated [R] hides on a zoom switch; the in-fullscreen [R] must stay
+	if (resetBtn.textContent === '[R]' && !iframe.parentElement.classList.contains('fullscreen'))
+		resetBtn.style.display = 'none';
 }
 
 function toggleFullscreen(frameId, btn) {
@@ -302,6 +304,8 @@ function toggleFullscreen(frameId, btn) {
 	} else {
 		const overlay = if1.querySelector('.overlay');
 		const resetBtn = getResetButtonFromFrameId(frameId);
+		// snapshot whether the overlay gate was up, to restore it on exit
+		if1._fsOverlayVisible = !overlay || overlay.style.display !== 'none';
 		if1.classList.add('fullscreen');
 		if1.previousElementSibling.classList.add('fullscreen');
 		document.body.classList.add('fs-lock');
@@ -311,21 +315,23 @@ function toggleFullscreen(frameId, btn) {
 		// show [R] in the top bar to reset the map to default without leaving
 		// fullscreen (reliable on desktop; mobile uses the bottom bar's Reset)
 		if (resetBtn) setResetButtonToFullscreenReset(resetBtn);
-		// mobile bottom bar (CSS hides it on desktop): big reliable Reset | Exit
-		// targets, where the tiny top-bar edge buttons aren't reachable
-		const exitBar = document.createElement('div');
-		exitBar.className = 'fs-exit-bar';
-		const resetZone = document.createElement('div');
-		resetZone.className = 'fs-bar-btn';
-		resetZone.textContent = 'Reset';
-		resetZone.addEventListener('click', () => resetIframePosition(frameId));
-		const exitZone = document.createElement('div');
-		exitZone.className = 'fs-bar-btn';
-		exitZone.textContent = 'Zatvori';
-		exitZone.addEventListener('click', () => exitFullscreen(if1));
-		exitBar.append(exitZone, resetZone);
-		document.body.appendChild(exitBar);
-		if1._fsExitBar = exitBar;
+		// mobile-only bottom bar (matches the CSS <=800px breakpoint): big reliable
+		// Zatvori | Reset targets, where the tiny top-bar edge buttons aren't reachable
+		if (window.innerWidth <= 800) {
+			const exitBar = document.createElement('div');
+			exitBar.className = 'fs-exit-bar';
+			const resetZone = document.createElement('div');
+			resetZone.className = 'fs-bar-btn';
+			resetZone.textContent = 'Reset';
+			resetZone.addEventListener('click', () => resetIframePosition(frameId));
+			const exitZone = document.createElement('div');
+			exitZone.className = 'fs-bar-btn';
+			exitZone.textContent = 'Zatvori';
+			exitZone.addEventListener('click', () => exitFullscreen(if1));
+			exitBar.append(exitZone, resetZone);
+			document.body.appendChild(exitBar);
+			if1._fsExitBar = exitBar;
+		}
 	}
 }
 
@@ -341,14 +347,22 @@ function exitFullscreen(if1) {
 	if (btn) btn.textContent = '[ ]';
 	if (!document.querySelector('.if1.fullscreen'))
 		document.body.classList.remove('fs-lock');
-	// the map was likely panned/zoomed in fullscreen, so return to the gated
-	// state and show the reset button as [R] for easy reset to default position
+	// restore the overlay gate to its pre-fullscreen lock state (tracked on enter)
+	const wasUnlocked = if1._fsOverlayVisible === false;
+	delete if1._fsOverlayVisible;
 	const overlay = if1.querySelector('.overlay');
-	if (overlay) overlay.removeAttribute('style');
+	if (overlay) {
+		if (wasUnlocked) overlay.style.display = 'none';
+		else overlay.removeAttribute('style');
+	}
+	// the map was likely panned/zoomed in fullscreen, so always show the reset
+	// button, matching the lock state: [X] (re-lock, then [R]) if it was
+	// unlocked, [R] (reset to default) if it was locked
 	const resetBtn = getResetButtonFromFrameId(if1.querySelector('iframe').id);
 	if (resetBtn) {
 		resetBtn.style.removeProperty('display');
-		setResetButtonToReset(resetBtn);
+		if (wasUnlocked) setResetButtonToExit(resetBtn);
+		else setResetButtonToReset(resetBtn);
 	}
 }
 

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -302,12 +302,6 @@ function toggleFullscreen(frameId, btn) {
 	} else {
 		const overlay = if1.querySelector('.overlay');
 		const resetBtn = getResetButtonFromFrameId(frameId);
-		// snapshot the current state (locked/interactive) to restore it on exit
-		if1._fsPrevState = {
-			overlayVisible: !overlay || overlay.style.display !== 'none',
-			resetVisible: !!resetBtn && resetBtn.style.display !== 'none',
-			resetMode: resetBtn && resetBtn.textContent === '[R]' ? 'reset' : 'exit'
-		};
 		if1.classList.add('fullscreen');
 		if1.previousElementSibling.classList.add('fullscreen');
 		document.body.classList.add('fs-lock');
@@ -338,24 +332,15 @@ function exitFullscreen(if1) {
 	if (btn) btn.textContent = '[ ]';
 	if (!document.querySelector('.if1.fullscreen'))
 		document.body.classList.remove('fs-lock');
-	// restore the pre-fullscreen state captured on enter
-	const prev = if1._fsPrevState || { overlayVisible: true, resetVisible: false, resetMode: 'exit' };
+	// the map was likely panned/zoomed in fullscreen, so return to the gated
+	// state and show the reset button as [R] for easy reset to default position
 	const overlay = if1.querySelector('.overlay');
-	if (overlay) {
-		if (prev.overlayVisible) overlay.removeAttribute('style');
-		else overlay.style.display = 'none';
-	}
+	if (overlay) overlay.removeAttribute('style');
 	const resetBtn = getResetButtonFromFrameId(if1.querySelector('iframe').id);
 	if (resetBtn) {
-		if (prev.resetVisible) {
-			resetBtn.style.removeProperty('display');
-			if (prev.resetMode === 'reset') setResetButtonToReset(resetBtn);
-			else setResetButtonToExit(resetBtn);
-		} else {
-			resetBtn.style.display = 'none';
-		}
+		resetBtn.style.removeProperty('display');
+		setResetButtonToReset(resetBtn);
 	}
-	delete if1._fsPrevState;
 }
 
 function hideOverlayOnDoubleTap() {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -294,6 +294,39 @@ function switchIframeZoom(frameId, btn) {
 	if (resetBtn.textContent === '[R]') resetBtn.style.display = 'none';
 }
 
+function toggleFullscreen(frameId, btn) {
+	dlog(`toggleFullscreen: ${frameId}`);
+	const if1 = document.getElementById(frameId).parentElement;
+	if (if1.classList.contains('fullscreen')) {
+		exitFullscreen(if1);
+	} else {
+		if1.classList.add('fullscreen');
+		if1.previousElementSibling.classList.add('fullscreen');
+		document.body.classList.add('fs-lock');
+		btn.textContent = '[-]';
+		// unlock interactivity: drop the overlay gate and hide the reset button
+		const overlay = if1.querySelector('.overlay');
+		if (overlay) overlay.style.display = 'none';
+		const resetBtn = getResetButtonFromFrameId(frameId);
+		if (resetBtn) resetBtn.style.display = 'none';
+	}
+}
+
+function exitFullscreen(if1) {
+	if1.classList.remove('fullscreen');
+	const title = if1.previousElementSibling;
+	title.classList.remove('fullscreen');
+	const btn = title.querySelector('.fs-btn');
+	if (btn) btn.textContent = '[ ]';
+	if (!document.querySelector('.if1.fullscreen'))
+		document.body.classList.remove('fs-lock');
+	// re-gate the map and offer the reset ([R]) button, since fullscreen was interactive
+	const frameId = if1.querySelector('iframe').id;
+	const resetBtn = getResetButtonFromFrameId(frameId);
+	if (resetBtn) resetBtn.style.removeProperty('display');
+	restoreOverlay(frameId);
+}
+
 function hideOverlayOnDoubleTap() {
 	const overlays = document.querySelectorAll('.if1 .overlay');
 
@@ -487,4 +520,9 @@ window.addEventListener('resize', () => {
 		updateHintText();
 		updateLinksScrollShadows();
 	}, 200);
+});
+
+document.addEventListener('keydown', (e) => {
+	if (e.key === 'Escape')
+		document.querySelectorAll('.if1.fullscreen').forEach(exitFullscreen);
 });

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -321,11 +321,11 @@ function toggleFullscreen(frameId, btn) {
 			const exitBar = document.createElement('div');
 			exitBar.className = 'fs-exit-bar';
 			const resetZone = document.createElement('div');
-			resetZone.className = 'fs-bar-btn';
+			resetZone.className = 'fs-bar-btn fs-reset';
 			resetZone.textContent = 'Reset';
 			resetZone.addEventListener('click', () => resetIframePosition(frameId));
 			const exitZone = document.createElement('div');
-			exitZone.className = 'fs-bar-btn';
+			exitZone.className = 'fs-bar-btn fs-exit';
 			exitZone.textContent = 'Zatvori';
 			exitZone.addEventListener('click', () => exitFullscreen(if1));
 			exitBar.append(exitZone, resetZone);

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -300,14 +300,20 @@ function toggleFullscreen(frameId, btn) {
 	if (if1.classList.contains('fullscreen')) {
 		exitFullscreen(if1);
 	} else {
+		const overlay = if1.querySelector('.overlay');
+		const resetBtn = getResetButtonFromFrameId(frameId);
+		// snapshot the current state (locked/interactive) to restore it on exit
+		if1._fsPrevState = {
+			overlayVisible: !overlay || overlay.style.display !== 'none',
+			resetVisible: !!resetBtn && resetBtn.style.display !== 'none',
+			resetMode: resetBtn && resetBtn.textContent === '[R]' ? 'reset' : 'exit'
+		};
 		if1.classList.add('fullscreen');
 		if1.previousElementSibling.classList.add('fullscreen');
 		document.body.classList.add('fs-lock');
 		btn.textContent = '[-]';
 		// unlock interactivity: drop the overlay gate and hide the reset button
-		const overlay = if1.querySelector('.overlay');
 		if (overlay) overlay.style.display = 'none';
-		const resetBtn = getResetButtonFromFrameId(frameId);
 		if (resetBtn) resetBtn.style.display = 'none';
 	}
 }
@@ -320,11 +326,24 @@ function exitFullscreen(if1) {
 	if (btn) btn.textContent = '[ ]';
 	if (!document.querySelector('.if1.fullscreen'))
 		document.body.classList.remove('fs-lock');
-	// re-gate the map and offer the reset ([R]) button, since fullscreen was interactive
-	const frameId = if1.querySelector('iframe').id;
-	const resetBtn = getResetButtonFromFrameId(frameId);
-	if (resetBtn) resetBtn.style.removeProperty('display');
-	restoreOverlay(frameId);
+	// restore the pre-fullscreen state captured on enter
+	const prev = if1._fsPrevState || { overlayVisible: true, resetVisible: false, resetMode: 'exit' };
+	const overlay = if1.querySelector('.overlay');
+	if (overlay) {
+		if (prev.overlayVisible) overlay.removeAttribute('style');
+		else overlay.style.display = 'none';
+	}
+	const resetBtn = getResetButtonFromFrameId(if1.querySelector('iframe').id);
+	if (resetBtn) {
+		if (prev.resetVisible) {
+			resetBtn.style.removeProperty('display');
+			if (prev.resetMode === 'reset') setResetButtonToReset(resetBtn);
+			else setResetButtonToExit(resetBtn);
+		} else {
+			resetBtn.style.display = 'none';
+		}
+	}
+	delete if1._fsPrevState;
 }
 
 function hideOverlayOnDoubleTap() {

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -346,6 +346,32 @@ function exitFullscreen(if1) {
 	delete if1._fsPrevState;
 }
 
+function addTitleTapActivation() {
+	// On mobile, the synthetic click after interacting with a cross-origin iframe
+	// (e.g. tapping the map's own zoom controls) can be swallowed, leaving the
+	// title-bar buttons unresponsive. Fire the action on touchend instead and
+	// preventDefault to suppress the now-redundant synthetic click (no double-fire).
+	// Delegated on .radartitle so it survives the reset button being recloned.
+	const sel = '.zoom-btn, .fs-btn, .right-cluster a';
+	document.querySelectorAll('.radartitle').forEach(bar => {
+		let sx = 0, sy = 0;
+		bar.addEventListener('touchstart', (e) => {
+			if (e.touches.length === 1) {
+				sx = e.touches[0].clientX;
+				sy = e.touches[0].clientY;
+			}
+		}, { passive: true });
+		bar.addEventListener('touchend', (e) => {
+			const a = e.target.closest('a');
+			if (!a || !bar.contains(a) || !a.matches(sel)) return;
+			const t = e.changedTouches[0];
+			if (Math.abs(t.clientX - sx) > 10 || Math.abs(t.clientY - sy) > 10) return; // treat as scroll/swipe
+			e.preventDefault(); // stop the (possibly swallowed) synthetic click from firing too
+			a.click();
+		});
+	});
+}
+
 function hideOverlayOnDoubleTap() {
 	const overlays = document.querySelectorAll('.if1 .overlay');
 
@@ -527,6 +553,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	addSwipeEvents();
 	updateIframeSrc();
 	hideOverlayOnDoubleTap();
+	addTitleTapActivation();
 	updateHintText();
 	initLinksBottom();
 	addLinksScrollShadows();

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -47,7 +47,7 @@ t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getRe
 dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 ;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
 ;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-document.body.classList.add("fs-lock"),t.textContent="[□]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
 function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
 ;const o=t.querySelector(".fs-btn")
 ;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -47,7 +47,7 @@ t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getRe
 dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 ;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
 ;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+document.body.classList.add("fs-lock"),t.textContent="[□]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
 function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
 ;const o=t.querySelector(".fs-btn")
 ;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -29,7 +29,7 @@ Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){
 ;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const a=n-t,l=s-o;Math.abs(a)>Math.abs(l)&&handleSwipe(e,t,n),r=!1}}),
+e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
 e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 ;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -48,32 +48,22 @@ t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getRe
 const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
 resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
 o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
-s&&(s.style.display="none")}}function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling
+s&&(s.style.display="none");const r=document.createElement("div");r.className="fs-exit-bar",r.textContent="✕ Zatvori cijeli zaslon",
+r.addEventListener("click",()=>exitFullscreen(o)),document.body.appendChild(r),o._fsExitBar=r}}function exitFullscreen(e){
+e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
 ;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
 document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
 resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
 ;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
 "reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
-1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
-const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
-;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function addTapDebugReadout(){
-if(!isDebugEnabled)return;const e=document.createElement("div");e.id="tapDebug",
-e.style.cssText="position:fixed;left:0;right:0;bottom:0;z-index:2147483647;pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all",
-e.textContent="tap debug ready",document.body.appendChild(e);const t={pointerdown:0,touchstart:0,touchend:0,click:0},o=(o,n)=>{t[o]++
-;const s=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0]||n,r=Math.round(s&&s.clientX||0),i=Math.round(s&&s.clientY||0)
-;e.textContent=`pd:${t.pointerdown} ts:${t.touchstart} te:${t.touchend} ck:${t.click}\nlast: ${o} @${r},${i}  fs:${!!document.querySelector(".if1.fullscreen")}\ntarget: ${(e=>{
-if(!(e instanceof Element))return String(e);let t=e.tagName.toLowerCase();return e.id&&(t+="#"+e.id),
-"string"==typeof e.className&&e.className.trim()&&(t+="."+e.className.trim().replace(/\s+/g,".")),t})(n.target)}`}
-;["pointerdown","touchstart","touchend","click"].forEach(e=>document.addEventListener(e,t=>o(e,t),!0))}function hideOverlayOnDoubleTap(){
-document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
-e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
-;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
-;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
-;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
-e.addEventListener("touchend",e=>{if(!n)return
-;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(o-s);i<10&&a<10&&(n.style.opacity="0.6",
+function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
+e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
+if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
+;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -94,6 +84,6 @@ function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),addTapDebugReadout(),updateHintText(),initLinksBottom(),
-addLinksScrollShadows()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{
-updateIframeSrc(),updateHintText(),updateLinksScrollShadows()},200)});
+updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
+updateHintText(),updateLinksScrollShadows()},200)});

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -54,13 +54,17 @@ document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lo
 resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
 ;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
 "reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
-e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
-;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
+1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
+const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
+;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function hideOverlayOnDoubleTap(){
+document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
+e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
+;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
+;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
+;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
+e.addEventListener("touchend",e=>{if(!n)return
 ;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
@@ -82,6 +86,6 @@ function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-updateIframeSrc(),hideOverlayOnDoubleTap(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
+updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
 window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
 updateHintText(),updateLinksScrollShadows()},200)});

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -25,11 +25,11 @@ const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1)
 document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,s=0,r=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
 o=e.touches[0].clientY),r=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?r=!1:(n=e.touches[0].clientX,s=e.touches[0].clientY,
-Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,i=s-o
-;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,l=s-o
+;Math.abs(r)>Math.abs(l)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+e.addEventListener("mouseup",l=>{if(r){n=l.clientX,s=l.clientY;const i=n-t,a=s-o;Math.abs(i)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
 e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 ;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -46,18 +46,14 @@ t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getRe
 ;"[R]"!==s.textContent||n.parentElement.classList.contains("fullscreen")||(s.style.display="none")}function toggleFullscreen(e,t){
 dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
 ;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
-;if(o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
-document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s),
-window.innerWidth<=800){const t=document.createElement("div");t.className="fs-exit-bar";const n=document.createElement("div")
-;n.className="fs-bar-btn fs-reset",n.textContent="Reset",n.addEventListener("click",()=>resetIframePosition(e))
-;const s=document.createElement("div");s.className="fs-bar-btn fs-exit",s.textContent="Zatvori",
-s.addEventListener("click",()=>exitFullscreen(o)),t.append(s,n),document.body.appendChild(t),o._fsExitBar=t}}}function exitFullscreen(e){
-e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
-;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
-document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=!1===e._fsOverlayVisible
-;delete e._fsOverlayVisible;const s=e.querySelector(".overlay");s&&(n?s.style.display="none":s.removeAttribute("style"))
-;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(r.style.removeProperty("display"),
-n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
+;o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
+document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s)}}
+function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling;t.classList.remove("fullscreen")
+;const o=t.querySelector(".fs-btn")
+;o&&(o.textContent="[ ]"),document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock")
+;const n=!1===e._fsOverlayVisible;delete e._fsOverlayVisible;const s=e.querySelector(".overlay")
+;s&&(n?s.style.display="none":s.removeAttribute("style"));const r=getResetButtonFromFrameId(e.querySelector("iframe").id)
+;r&&(r.style.removeProperty("display"),n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
 document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
 ;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
@@ -65,7 +61,7 @@ e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(
 ;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
 ;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
 e.addEventListener("touchend",e=>{if(!n)return
-;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
+;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,l=Math.abs(t-r),i=Math.abs(o-s);l<10&&i<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -43,26 +43,28 @@ const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",s="eu"===t?"data-
 ;o=o.replace(e.getAttribute(n),e.getAttribute(s))}e.src=o}function switchIframeZoom(e,t){
 const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
 t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getResetButtonFromFrameId(e)
-;"[R]"===s.textContent&&(s.style.display="none")}function toggleFullscreen(e,t){dlog(`toggleFullscreen: ${e}`)
-;const o=document.getElementById(e).parentElement;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{
-const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
-resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
-o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
-s&&(s.style.display="none");const r=document.createElement("div");r.className="fs-exit-bar",r.textContent="✕ Zatvori cijeli zaslon",
-r.addEventListener("click",()=>exitFullscreen(o)),document.body.appendChild(r),o._fsExitBar=r}}function exitFullscreen(e){
+;"[R]"!==s.textContent||n.parentElement.classList.contains("fullscreen")||(s.style.display="none")}function toggleFullscreen(e,t){
+dlog(`toggleFullscreen: ${e}`);const o=document.getElementById(e).parentElement
+;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e)
+;if(o._fsOverlayVisible=!n||"none"!==n.style.display,o.classList.add("fullscreen"),o.previousElementSibling.classList.add("fullscreen"),
+document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),s&&setResetButtonToFullscreenReset(s),
+window.innerWidth<=800){const t=document.createElement("div");t.className="fs-exit-bar";const n=document.createElement("div")
+;n.className="fs-bar-btn fs-reset",n.textContent="Reset",n.addEventListener("click",()=>resetIframePosition(e))
+;const s=document.createElement("div");s.className="fs-bar-btn fs-exit",s.textContent="Zatvori",
+s.addEventListener("click",()=>exitFullscreen(o)),t.append(s,n),document.body.appendChild(t),o._fsExitBar=t}}}function exitFullscreen(e){
 e.classList.remove("fullscreen"),e._fsExitBar&&(e._fsExitBar.remove(),delete e._fsExitBar);const t=e.previousElementSibling
 ;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
-document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
-resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
-;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
-"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
-function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
-e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
-e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
-;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
-s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=!1===e._fsOverlayVisible
+;delete e._fsOverlayVisible;const s=e.querySelector(".overlay");s&&(n?s.style.display="none":s.removeAttribute("style"))
+;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(r.style.removeProperty("display"),
+n?setResetButtonToExit(r):setResetButtonToReset(r))}function hideOverlayOnDoubleTap(){
+document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
+e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
+;const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none";let t=getResetButtonFromOverlayId(e.id)
+;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
+;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
+e.addEventListener("touchend",e=>{if(!n)return
 ;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
@@ -75,10 +77,14 @@ restoreOverlay(getFrameIdFromResetButtonId(t.id))}),t.textContent="[X]"}function
 dlog(`setResetButtonToReset: ${e.id}`);const t=e.cloneNode(!0);e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{
 e.stopPropagation(),resetIframe(getFrameIdFromResetButtonId(t.id))}),t.textContent="[R]"}function resetIframe(e){
 dlog(`Resetting iframe: ${e}`),setIframeSrc(document.getElementById(e));const t=getResetButtonFromFrameId(e);t.style.display="none",
-setResetButtonToExit(t)}function getResetButtonFromFrameId(e){return document.querySelector(`a[data-frame-id="${e}"]`)}
-function getResetButtonFromOverlayId(e){return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}
-function getFrameIdFromResetButtonId(e){return document.getElementById(e).getAttribute("data-frame-id")}function GetLastInit(){
-let e=new Date;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
+setResetButtonToExit(t)}function resetIframePosition(e){dlog(`resetIframePosition: ${e}`),setIframeSrc(document.getElementById(e))}
+function setResetButtonToFullscreenReset(e){dlog(`setResetButtonToFullscreenReset: ${e.id}`);const t=e.cloneNode(!0)
+;e.parentNode.replaceChild(t,e),t.addEventListener("click",e=>{e.stopPropagation(),resetIframePosition(getFrameIdFromResetButtonId(t.id))}),
+t.textContent="[R]",t.style.removeProperty("display")}function getResetButtonFromFrameId(e){
+return document.querySelector(`a[data-frame-id="${e}"]`)}function getResetButtonFromOverlayId(e){
+return getResetButtonFromFrameId(document.getElementById(e).getAttribute("data-frame-id"))}function getFrameIdFromResetButtonId(e){
+return document.getElementById(e).getAttribute("data-frame-id")}function GetLastInit(){let e=new Date
+;return e=new Date(Date.UTC(e.getUTCFullYear(),e.getUTCMonth(),e.getUTCDate(),e.getUTCHours()>=12?12:0,0,0,0)),e}
 function DTGFromDateInHours(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+pad(e.getUTCHours(),2)}
 function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,2)+pad(e.getUTCDate(),2)+"06"}function pad(e,t,o){
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -11,9 +11,9 @@ const e=document.querySelector(".links-toggle");e&&(e.checked="1"===localStorage
 document.body.classList.toggle("show-links-bottom",e.checked))}function plusSlides(e,t){
 const o=document.querySelector(`.slideshow[data-slideshow-id="${e}"]`);showSlides(o,parseInt(o.getAttribute("data-current-slide"))+t)}
 function showSlides(e,t){
-const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),r=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
-;let s=t;s>n.length&&(s=1),s<1&&(s=n.length),e.setAttribute("data-current-slide",s),n.forEach(e=>e.classList.remove("active")),
-n[s-1].classList.add("active"),r.forEach(e=>e.classList.remove("active")),r[s-1].classList.add("active"),updateSlideshowWidth(e)}
+const o=e.getAttribute("data-slideshow-id"),n=e.querySelectorAll(".slide"),s=document.querySelectorAll(`.indicators-container[data-slideshow-id="${o}"] .indicator`)
+;let r=t;r>n.length&&(r=1),r<1&&(r=n.length),e.setAttribute("data-current-slide",r),n.forEach(e=>e.classList.remove("active")),
+n[r-1].classList.add("active"),s.forEach(e=>e.classList.remove("active")),s[r-1].classList.add("active"),updateSlideshowWidth(e)}
 function updateSlideshowWidth(e){if(!e.hasAttribute("data-dynamic-width"))return
 ;const t=e.getAttribute("data-slideshow-id"),o=document.querySelector(`.indicators-container[data-slideshow-id='${t}']`),n=e.querySelector(".slide.active .placeholder")
 ;e.style.maxWidth=n.style.maxWidth,o.style.maxWidth=n.style.maxWidth}function showProgress(){
@@ -22,15 +22,15 @@ const e=document.querySelectorAll("img"),t=document.querySelector(".progress-bar
 e.addEventListener("load",()=>{o++,n()}),e.addEventListener("error",()=>{o++,dlog(`Error loading image: ${e.src}`),e.removeAttribute("src"),
 n()}),e.complete&&e.dispatchEvent(new Event("load"))})}function handleSwipe(e,t,o){const n=o-t;if(Math.abs(n)>50){
 const t=parseInt(e.getAttribute("data-current-slide"));showSlides(e,t+(n>0?-1:1))}}function addSwipeEvents(){
-document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,r=0,s=!1;e.querySelectorAll("img").forEach(e=>{
+document.querySelectorAll(".slideshow").forEach(e=>{let t=0,o=0,n=0,s=0,r=!1;e.querySelectorAll("img").forEach(e=>{
 e.addEventListener("dragstart",e=>e.preventDefault())}),e.addEventListener("touchstart",e=>{e.touches.length>1||(t=e.touches[0].clientX,
-o=e.touches[0].clientY),s=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?s=!1:(n=e.touches[0].clientX,r=e.touches[0].clientY,
-Math.abs(n-t)>Math.abs(r-o)&&(s=!0))}),e.addEventListener("touchend",()=>{if(s){const s=n-t,i=r-o
-;Math.abs(s)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
+o=e.touches[0].clientY),r=!1}),e.addEventListener("touchmove",e=>{e.touches.length>1?r=!1:(n=e.touches[0].clientX,s=e.touches[0].clientY,
+Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){const r=n-t,i=s-o
+;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
-e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,s=!0}),e.addEventListener("mousemove",e=>{s&&(n=e.clientX,r=e.clientY)}),
-e.addEventListener("mouseup",i=>{if(s){n=i.clientX,r=i.clientY;const a=n-t,d=r-o;Math.abs(a)>Math.abs(d)&&handleSwipe(e,t,n),s=!1}}),
-e.addEventListener("mouseleave",()=>{s&&(s=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
+e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
+e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 ;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(e=>{e.addEventListener("scroll",()=>updateLinksScrollShadow(e),{passive:!0})}),
@@ -39,18 +39,29 @@ window.innerWidth!==previousWidth&&(previousWidth=window.innerWidth,
 document.querySelectorAll("iframe[data-zoom-hr-desktop]").forEach(e=>setIframeSrc(e)))}function setIframeSrc(e){
 dlog(`Updating iframe src for ${e.id}`);const t=e.getAttribute("data-zoom-mode")
 ;let o="eu"===t?e.getAttribute("data-src-eu"):e.getAttribute("data-src-hr");if(window.innerWidth<800){
-const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",r="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
-;o=o.replace(e.getAttribute(n),e.getAttribute(r))}e.src=o}function switchIframeZoom(e,t){
+const n="eu"===t?"data-zoom-eu-desktop":"data-zoom-hr-desktop",s="eu"===t?"data-zoom-eu-mobile":"data-zoom-hr-mobile"
+;o=o.replace(e.getAttribute(n),e.getAttribute(s))}e.src=o}function switchIframeZoom(e,t){
 const o="hr"===t.getAttribute("data-mode")?"eu":"hr",n=document.getElementById(e);n.setAttribute("data-zoom-mode",o),setIframeSrc(n),
-t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const r=getResetButtonFromFrameId(e)
-;"[R]"===r.textContent&&(r.style.display="none")}function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{
-let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),
-setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
-if(o)return void(0===n.touches.length&&(o=!1,t=0));const r=(new Date).getTime(),s=r-t;if(s>0&&s<200){e.style.display="none"
-;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=r})
-;const n=e.querySelector(".hint");let r=0,s=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(s=e.touches[0].clientX,
-r=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
-;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-s),a=Math.abs(o-r);i<10&&a<10&&(n.style.opacity="0.6",
+t.setAttribute("data-mode",o),t.textContent="hr"===o?"[HR]":"[EU]";const s=getResetButtonFromFrameId(e)
+;"[R]"===s.textContent&&(s.style.display="none")}function toggleFullscreen(e,t){dlog(`toggleFullscreen: ${e}`)
+;const o=document.getElementById(e).parentElement;if(o.classList.contains("fullscreen"))exitFullscreen(o);else{
+const n=o.querySelector(".overlay"),s=getResetButtonFromFrameId(e);o._fsPrevState={overlayVisible:!n||"none"!==n.style.display,
+resetVisible:!!s&&"none"!==s.style.display,resetMode:s&&"[R]"===s.textContent?"reset":"exit"},o.classList.add("fullscreen"),
+o.previousElementSibling.classList.add("fullscreen"),document.body.classList.add("fs-lock"),t.textContent="[-]",n&&(n.style.display="none"),
+s&&(s.style.display="none")}}function exitFullscreen(e){e.classList.remove("fullscreen");const t=e.previousElementSibling
+;t.classList.remove("fullscreen");const o=t.querySelector(".fs-btn");o&&(o.textContent="[ ]"),
+document.querySelector(".if1.fullscreen")||document.body.classList.remove("fs-lock");const n=e._fsPrevState||{overlayVisible:!0,
+resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVisible?s.removeAttribute("style"):s.style.display="none")
+;const r=getResetButtonFromFrameId(e.querySelector("iframe").id);r&&(n.resetVisible?(r.style.removeProperty("display"),
+"reset"===n.resetMode?setResetButtonToReset(r):setResetButtonToExit(r)):r.style.display="none"),delete e._fsPrevState}
+function hideOverlayOnDoubleTap(){document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{
+e.style.display="none";let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),
+e.addEventListener("touchstart",e=>{e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{
+if(o)return void(0===n.touches.length&&(o=!1,t=0));const s=(new Date).getTime(),r=s-t;if(r>0&&r<200){e.style.display="none"
+;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s})
+;const n=e.querySelector(".hint");let s=0,r=0;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,
+s=e.touches[0].clientY)}),e.addEventListener("touchend",e=>{if(!n)return
+;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}

--- a/src/_assets/js/main.min.js
+++ b/src/_assets/js/main.min.js
@@ -29,7 +29,7 @@ Math.abs(n-t)>Math.abs(s-o)&&(r=!0))}),e.addEventListener("touchend",()=>{if(r){
 ;Math.abs(r)>Math.abs(i)&&handleSwipe(e,t,n)}}),e.querySelectorAll(".prev, .next").forEach(e=>{let t=!1;e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(t=!0)}),e.addEventListener("touchend",e=>{t&&e.preventDefault(),0===e.touches.length&&(t=!1)})}),
 e.addEventListener("mousedown",e=>{t=e.clientX,o=e.clientY,r=!0}),e.addEventListener("mousemove",e=>{r&&(n=e.clientX,s=e.clientY)}),
-e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const l=n-t,a=s-o;Math.abs(l)>Math.abs(a)&&handleSwipe(e,t,n),r=!1}}),
+e.addEventListener("mouseup",i=>{if(r){n=i.clientX,s=i.clientY;const a=n-t,l=s-o;Math.abs(a)>Math.abs(l)&&handleSwipe(e,t,n),r=!1}}),
 e.addEventListener("mouseleave",()=>{r&&(r=!1)})})}function updateLinksScrollShadow(e){const t=e.scrollWidth-e.clientWidth,o=e.scrollLeft
 ;e.classList.toggle("can-scroll-left",o>1),e.classList.toggle("can-scroll-right",t>1&&o<t-1)}function updateLinksScrollShadows(){
 document.querySelectorAll(".links-bottom").forEach(updateLinksScrollShadow)}function addLinksScrollShadows(){
@@ -57,7 +57,15 @@ resetVisible:!1,resetMode:"exit"},s=e.querySelector(".overlay");s&&(n.overlayVis
 function addTitleTapActivation(){document.querySelectorAll(".radartitle").forEach(e=>{let t=0,o=0;e.addEventListener("touchstart",e=>{
 1===e.touches.length&&(t=e.touches[0].clientX,o=e.touches[0].clientY)},{passive:!0}),e.addEventListener("touchend",n=>{
 const s=n.target.closest("a");if(!s||!e.contains(s)||!s.matches(".zoom-btn, .fs-btn, .right-cluster a"))return;const r=n.changedTouches[0]
-;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function hideOverlayOnDoubleTap(){
+;Math.abs(r.clientX-t)>10||Math.abs(r.clientY-o)>10||(n.preventDefault(),s.click())})})}function addTapDebugReadout(){
+if(!isDebugEnabled)return;const e=document.createElement("div");e.id="tapDebug",
+e.style.cssText="position:fixed;left:0;right:0;bottom:0;z-index:2147483647;pointer-events:none;background:rgba(0,0,0,.8);color:#0f0;font:12px/1.4 monospace;padding:4px 6px;white-space:pre-wrap;word-break:break-all",
+e.textContent="tap debug ready",document.body.appendChild(e);const t={pointerdown:0,touchstart:0,touchend:0,click:0},o=(o,n)=>{t[o]++
+;const s=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0]||n,r=Math.round(s&&s.clientX||0),i=Math.round(s&&s.clientY||0)
+;e.textContent=`pd:${t.pointerdown} ts:${t.touchstart} te:${t.touchend} ck:${t.click}\nlast: ${o} @${r},${i}  fs:${!!document.querySelector(".if1.fullscreen")}\ntarget: ${(e=>{
+if(!(e instanceof Element))return String(e);let t=e.tagName.toLowerCase();return e.id&&(t+="#"+e.id),
+"string"==typeof e.className&&e.className.trim()&&(t+="."+e.className.trim().replace(/\s+/g,".")),t})(n.target)}`}
+;["pointerdown","touchstart","touchend","click"].forEach(e=>document.addEventListener(e,t=>o(e,t),!0))}function hideOverlayOnDoubleTap(){
 document.querySelectorAll(".if1 .overlay").forEach(e=>{let t=0,o=!1;e.addEventListener("dblclick",()=>{e.style.display="none"
 ;let t=getResetButtonFromOverlayId(e.id);t.removeAttribute("style"),setResetButtonToExit(t)}),e.addEventListener("touchstart",e=>{
 e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(0===n.touches.length&&(o=!1,t=0))
@@ -65,7 +73,7 @@ e.touches.length>1&&(o=!0)}),e.addEventListener("touchend",n=>{if(o)return void(
 ;t.removeAttribute("style"),setResetButtonToExit(t),n.preventDefault()}t=s});const n=e.querySelector(".hint");let s=0,r=0
 ;e.addEventListener("touchstart",e=>{1===e.touches.length&&(r=e.touches[0].clientX,s=e.touches[0].clientY)}),
 e.addEventListener("touchend",e=>{if(!n)return
-;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),l=Math.abs(o-s);i<10&&l<10&&(n.style.opacity="0.6",
+;const t=e.changedTouches[0].clientX,o=e.changedTouches[0].clientY,i=Math.abs(t-r),a=Math.abs(o-s);i<10&&a<10&&(n.style.opacity="0.6",
 clearTimeout(n._hideTimer),n._hideTimer=setTimeout(()=>{n.style.removeProperty("opacity")},2e3))})})}function updateHintText(){
 const e=window.innerWidth<800;document.querySelectorAll(".hint").forEach(t=>{
 t.textContent=e?"Dvostruki dodir za pristup interaktivnoj karti":"Dvostruki klik za pristup interaktivnoj karti"})}
@@ -86,6 +94,6 @@ function EndValue(e){return e.getUTCFullYear().toString()+pad(e.getUTCMonth()+1,
 return String(e).padStart(t,o||"0")}const isDebugEnabled="1"===new URLSearchParams(window.location.search).get("debug");function dlog(...e){
 isDebugEnabled&&console.log(...e)}document.addEventListener("DOMContentLoaded",()=>{document.querySelectorAll("img.lazy").forEach(e=>{
 e.src=e.getAttribute("data-src"),e.classList.remove("lazy")}),showProgress(),addExpandableClickEventListener(),addSwipeEvents(),
-updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),updateHintText(),initLinksBottom(),addLinksScrollShadows()}),
-window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{updateIframeSrc(),
-updateHintText(),updateLinksScrollShadows()},200)});
+updateIframeSrc(),hideOverlayOnDoubleTap(),addTitleTapActivation(),addTapDebugReadout(),updateHintText(),initLinksBottom(),
+addLinksScrollShadows()}),window.addEventListener("resize",()=>{clearTimeout(window._resizeTimeout),window._resizeTimeout=setTimeout(()=>{
+updateIframeSrc(),updateHintText(),updateLinksScrollShadows()},200)});

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -40,7 +40,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventusky', this)">[HR]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
-						<a class="right" id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('ventusky', this)">[ ]</a>
+							<a id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="ventusky" class="scaled-iframe" loading="eager" frameborder="0"
@@ -74,7 +77,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('rainViewer', this)">[HR]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
-						<a class="right" id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('rainViewer', this)">[ ]</a>
+							<a id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="rainViewer" class="scaled-iframe" loading="lazy" frameborder="0"
@@ -108,7 +114,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
-						<a class="right" id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('weatherAndRadar', this)">[ ]</a>
+							<a id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="weatherAndRadar" class="scaled-iframe" loading="lazy" frameborder="0" data-zoom-hr-desktop="&zoom=7.2" data-zoom-hr-mobile="&zoom=6.8" data-zoom-eu-desktop="&zoom=5.0" data-zoom-eu-mobile="&zoom=4.0"

--- a/src/extras/index.html
+++ b/src/extras/index.html
@@ -41,8 +41,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('ventusky', this)">[HR]</a>
 						<a class="center" href="https://www.ventusky.com/?p=44.5;16.5;6&l=radar&w=off" target="_blank" rel="nofollow">Ventusky</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('ventusky', this)">[ ]</a>
 							<a id="resetVentuskyFrame" data-frame-id="ventusky" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('ventusky', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">
@@ -78,8 +78,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('rainViewer', this)">[HR]</a>
 						<a class="center" href="https://www.rainviewer.com/map.html?loc=44.5,16.5,6&oCS=1&c=5&lm=1&layer=radar&sm=1&sn=2&ts=1" target="_blank" rel="nofollow">Rain Viewer</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('rainViewer', this)">[ ]</a>
 							<a id="resetRainViewerFrame" data-frame-id="rainViewer" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('rainViewer', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">
@@ -115,8 +115,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('weatherAndRadar', this)">[HR]</a>
 						<a class="center" href="https://www.vrijemeradar.hr/vremenski-radar/zagreb/18138691?center=44.5,16.5&zoom=7&layer=wr&tz=Europe%2FZagreb" target="_blank" rel="nofollow">Vrijeme&Radar</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('weatherAndRadar', this)">[ ]</a>
 							<a id="resetWeatherAndRadarFrame" data-frame-id="weatherAndRadar" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('weatherAndRadar', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">

--- a/src/index.html
+++ b/src/index.html
@@ -202,7 +202,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('windy', this)">[HR]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
-						<a class="right" id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('windy', this)">[ ]</a>
+							<a id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="windy" loading="lazy" frameborder="0"
@@ -317,7 +320,10 @@
 					<div class="radartitle">
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
-						<a class="right" id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
+						<span class="right right-cluster">
+							<a class="fs-btn" onclick="toggleFullscreen('blitzortung', this)">[ ]</a>
+							<a id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
+						</span>
 					</div>
 					<div class="if1 placeholder">
 						<iframe id="blitzortung" loading="lazy" frameborder="0"

--- a/src/index.html
+++ b/src/index.html
@@ -203,8 +203,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('windy', this)">[HR]</a>
 						<a class="center" href="https://www.windy.com/-Radar-lightning-radar?radar,44.5,16.5,7" target="_blank" rel="nofollow">Windy</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('windy', this)">[ ]</a>
 							<a id="resetWindyFrame" data-frame-id="windy" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('windy', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">
@@ -321,8 +321,8 @@
 						<a class="left zoom-btn" data-mode="hr" onclick="switchIframeZoom('blitzortung', this)">[HR]</a>
 						<a class="center" href="https://map.blitzortung.org/#6/44.5/16.5" target="_blank" rel="nofollow">Blitzortung.org | Munje</a>
 						<span class="right right-cluster">
-							<a class="fs-btn" onclick="toggleFullscreen('blitzortung', this)">[ ]</a>
 							<a id="resetBlitzortungFrame" data-frame-id="blitzortung" style="display:none">[X]</a>
+							<a class="fs-btn" onclick="toggleFullscreen('blitzortung', this)">[ ]</a>
 						</span>
 					</div>
 					<div class="if1 placeholder">


### PR DESCRIPTION
- Adds a `[ ]`/`[-]` fullscreen toggle to each embedded map title bar (Windy, Blitzortung, Ventusky, Rain Viewer, Vrijeme&Radar) that pins the title row to the top and expands the map to fill the viewport (`body.fs-lock` prevents background scroll).
- Drops the interaction overlay on enter so the map is immediately pannable/zoomable, then **restores the prior lock state on exit**: a map left unlocked comes back unlocked with `[X]`; a gated map comes back gated with `[R]`.
- Keeps a reset button available throughout — `[R]` in fullscreen reloads the map to its default position without leaving fullscreen, and the reset button is always shown on exit since the map was likely panned.
- Mobile-tuned title bar: taller (32px) fullscreen bar, flex-centered items, wider button gaps, edge margins, and enlarged `::before` tap targets so the small glyphs are reliably tappable on touch screens.
- Groups the reset and fullscreen buttons into a right-side `.right-cluster`; no changes to existing map behavior outside fullscreen.
